### PR TITLE
Ensure admin portal defaults to English and secure booking access

### DIFF
--- a/app/(public)/booking/page.tsx
+++ b/app/(public)/booking/page.tsx
@@ -1,3 +1,6 @@
+import { redirect } from "next/navigation";
+
+import { getCurrentUser } from "@/lib/auth";
 import { prisma } from "@/lib/db";
 import { getDictionary, getLocale } from "@/lib/i18n";
 import { BookingForm } from "@/components/booking/booking-form";
@@ -6,6 +9,11 @@ import type { BookingCourse } from "@/lib/types/booking";
 export const dynamic = "force-dynamic";
 
 export default async function BookingPage() {
+  const user = await getCurrentUser();
+  if (!user) {
+    redirect("/login");
+  }
+
   const locale = await getLocale();
   const dictionary = await getDictionary(locale);
 

--- a/app/admin/appointments/page.tsx
+++ b/app/admin/appointments/page.tsx
@@ -33,8 +33,8 @@ export default async function AdminAppointmentsPage() {
   return (
     <section className="space-y-6">
       <div className="rounded-3xl bg-white/80 p-6 shadow-soft ring-1 ring-brand-100">
-        <h1 className="font-display text-3xl text-brand-800">إدارة المواعيد</h1>
-        <p className="text-brand-600">قم بتحديث حالة الجلسات، إضافة ملاحظات، أو إعادة الجدولة.</p>
+        <h1 className="font-display text-3xl text-brand-800">Manage appointments</h1>
+        <p className="text-brand-600">Update session status, leave notes for instructors, or reschedule bookings.</p>
       </div>
       <AppointmentsTable appointments={appointments} />
     </section>

--- a/app/admin/calendar/page.tsx
+++ b/app/admin/calendar/page.tsx
@@ -1,7 +1,8 @@
 import { addMonths, endOfMonth, startOfMonth, subMonths } from "date-fns";
 
 import { prisma } from "@/lib/db";
-import { getDictionary, getLocale } from "@/lib/i18n";
+import { getDictionary } from "@/lib/i18n";
+import type { Locale } from "@/lib/i18n";
 import type { AdminDictionary } from "@/lib/types/admin";
 import { AdminCalendar } from "@/components/admin/calendar/admin-calendar";
 
@@ -20,7 +21,7 @@ type CalendarAppointment = {
 };
 
 export default async function AdminCalendarPage() {
-  const locale = await getLocale();
+  const locale: Locale = "en";
   const dictionary = await getDictionary(locale);
 
   const now = new Date();

--- a/app/admin/cash-booking/page.tsx
+++ b/app/admin/cash-booking/page.tsx
@@ -36,13 +36,13 @@ export default async function AdminCashBookingPage() {
   return (
     <section className="space-y-6">
       <div className="rounded-3xl bg-white/80 p-6 shadow-soft ring-1 ring-brand-100">
-        <h1 className="font-display text-3xl text-brand-800">حجز نقدي</h1>
-        <p className="text-brand-600">أنشئ حجزاً للمتعلمين الذين يدفعون نقداً وأصدر إيصالاً فورياً.</p>
+        <h1 className="font-display text-3xl text-brand-800">Cash booking</h1>
+        <p className="text-brand-600">Create bookings for learners paying in cash and issue receipts instantly.</p>
       </div>
       <Card>
         <CardHeader>
-          <CardTitle>تفاصيل الحجز</CardTitle>
-          <CardDescription>املأ بيانات المتعلم، اختر الدورة، وأدخل معلومات الإيصال.</CardDescription>
+          <CardTitle>Booking details</CardTitle>
+          <CardDescription>Fill in learner information, pick a course, and record the receipt details.</CardDescription>
         </CardHeader>
         <CardContent>
           <CashBookingForm courses={courses} />

--- a/app/admin/catalog/page.tsx
+++ b/app/admin/catalog/page.tsx
@@ -1,12 +1,13 @@
 import { prisma } from "@/lib/db";
-import { getDictionary, getLocale } from "@/lib/i18n";
+import { getDictionary } from "@/lib/i18n";
+import type { Locale } from "@/lib/i18n";
 import type { AdminCatalogCourse } from "@/lib/types/admin";
 import { CatalogManager } from "@/components/admin/catalog/catalog-manager";
 
 export const dynamic = "force-dynamic";
 
 export default async function AdminCatalogPage() {
-  const locale = await getLocale();
+  const locale: Locale = "en";
   const dictionary = await getDictionary(locale);
 
   let courses: AdminCatalogCourse[] = [];

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -2,15 +2,16 @@ import Link from "next/link";
 import { redirect } from "next/navigation";
 
 import { getCurrentUser } from "@/lib/auth";
-import { getDictionary, getLocale } from "@/lib/i18n";
+import { getDictionary } from "@/lib/i18n";
+import type { Locale } from "@/lib/i18n";
 
 export default async function AdminLayout({ children }: { children: React.ReactNode }) {
   const user = await getCurrentUser();
   if (!user || user.role !== "ADMIN") {
-    redirect("/login");
+    redirect("/admin/login");
   }
 
-  const locale = await getLocale();
+  const locale: Locale = "en";
   const dictionary = await getDictionary(locale);
   const navItems = [
     { href: "/admin", label: dictionary.admin.nav.overview },

--- a/app/admin/login/page.tsx
+++ b/app/admin/login/page.tsx
@@ -1,0 +1,33 @@
+import { redirect } from "next/navigation";
+
+import { AdminLoginForm } from "@/components/admin/auth/admin-login-form";
+import { getCurrentUser } from "@/lib/auth";
+
+export const dynamic = "force-dynamic";
+
+export default async function AdminLoginPage() {
+  const user = await getCurrentUser();
+
+  if (user?.role === "ADMIN") {
+    redirect("/admin");
+  }
+
+  if (user && user.role !== "ADMIN") {
+    redirect("/");
+  }
+
+  return (
+    <section className="flex justify-center">
+      <div className="w-full max-w-lg space-y-6 rounded-3xl bg-white/80 p-8 shadow-soft ring-1 ring-brand-100">
+        <div className="space-y-2 text-center">
+          <h1 className="font-display text-3xl text-brand-800">Admin Portal Access</h1>
+          <p className="text-sm text-brand-500">
+            Sign in with your administrator credentials to manage courses, bookings, and learners.
+          </p>
+        </div>
+        <AdminLoginForm />
+      </div>
+    </section>
+  );
+}
+

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,13 +1,14 @@
 import { prisma } from "@/lib/db";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { getDictionary, getLocale } from "@/lib/i18n";
+import { getDictionary } from "@/lib/i18n";
+import type { Locale } from "@/lib/i18n";
 import type { AdminDictionary } from "@/lib/types/admin";
 
 export const dynamic = "force-dynamic";
 
 export default async function AdminOverviewPage() {
-  const locale = await getLocale();
+  const locale: Locale = "en";
   const dictionary = await getDictionary(locale);
 
   let stats = {

--- a/app/admin/reports/page.tsx
+++ b/app/admin/reports/page.tsx
@@ -1,5 +1,6 @@
 import { prisma } from "@/lib/db";
-import { getDictionary, getLocale } from "@/lib/i18n";
+import { getDictionary } from "@/lib/i18n";
+import type { Locale } from "@/lib/i18n";
 import type { AdminDictionary } from "@/lib/types/admin";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 
@@ -34,7 +35,7 @@ function formatUtilization(copy: string, utilization: ReportsData["utilization"]
 }
 
 export default async function AdminReportsPage() {
-  const locale = await getLocale();
+  const locale: Locale = "en";
   const dictionary = await getDictionary(locale);
 
   const data: ReportsData = {

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -25,28 +25,28 @@ export default async function AdminUsersPage() {
   return (
     <section className="space-y-6">
       <div className="rounded-3xl bg-white/80 p-6 shadow-soft ring-1 ring-brand-100">
-        <h1 className="font-display text-3xl text-brand-800">المتعلمون</h1>
-        <p className="text-brand-600">آخر المتعلمين المسجلين وعدد حجوزاتهم.</p>
+        <h1 className="font-display text-3xl text-brand-800">Learners</h1>
+        <p className="text-brand-600">Recently registered learners and their booking activity.</p>
       </div>
       <Card>
         <CardHeader>
-          <CardTitle>قائمة المتعلمين</CardTitle>
-          <CardDescription>أحدث 20 متعلم.</CardDescription>
+          <CardTitle>Learner list</CardTitle>
+          <CardDescription>The latest 20 learners in the platform.</CardDescription>
         </CardHeader>
         <CardContent className="space-y-3">
           {users.map((user) => (
             <div key={user.id} className="rounded-2xl border border-brand-100 bg-white/80 p-4">
               <div className="flex flex-wrap items-center justify-between gap-2">
                 <div>
-                  <p className="text-sm font-semibold text-brand-800">{user.name ?? "غير معروف"}</p>
+                  <p className="text-sm font-semibold text-brand-800">{user.name ?? "Unknown"}</p>
                   <p className="text-xs text-brand-500">{user.email}</p>
                 </div>
-                <div className="text-xs text-brand-500">الدور: {user.role}</div>
-                <div className="text-xs text-brand-500">الحجوزات: {user.bookings}</div>
+                <div className="text-xs text-brand-500">Role: {user.role}</div>
+                <div className="text-xs text-brand-500">Bookings: {user.bookings}</div>
               </div>
             </div>
           ))}
-          {users.length === 0 && <p className="text-brand-500">لم يتم العثور على متعلمين.</p>}
+          {users.length === 0 && <p className="text-brand-500">No learners found.</p>}
         </CardContent>
       </Card>
     </section>

--- a/app/api/admin/session/route.ts
+++ b/app/api/admin/session/route.ts
@@ -1,0 +1,52 @@
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+
+import { prisma } from "@/lib/db";
+import { getFirebaseAdmin } from "@/lib/firebase-admin";
+import { LOCALE_COOKIE } from "@/lib/i18n-config";
+
+const SESSION_MAX_AGE = 60 * 60 * 24 * 7; // 7 days
+
+export async function POST(request: Request) {
+  try {
+    const { idToken } = (await request.json()) as { idToken?: string };
+
+    if (!idToken) {
+      return NextResponse.json({ error: "ID token is required" }, { status: 400 });
+    }
+
+    const auth = getFirebaseAdmin();
+    const decoded = await auth.verifyIdToken(idToken);
+
+    const user = await prisma.user.findUnique({
+      where: { firebaseUid: decoded.uid },
+    });
+
+    if (!user || user.role !== "ADMIN") {
+      return NextResponse.json({ error: "Administrator access required" }, { status: 403 });
+    }
+
+    const cookieStore = cookies();
+    cookieStore.set("session", idToken, {
+      httpOnly: true,
+      secure: true,
+      sameSite: "lax",
+      maxAge: SESSION_MAX_AGE,
+      path: "/",
+    });
+
+    cookieStore.set({
+      name: LOCALE_COOKIE,
+      value: "en",
+      path: "/",
+      sameSite: "lax",
+      maxAge: 60 * 60 * 24 * 365,
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("POST /api/admin/session", error);
+    return NextResponse.json({ error: "Failed to create admin session" }, { status: 500 });
+  }
+}
+

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -11,23 +11,23 @@ import { usePreferencesStore } from "@/stores/preferences";
 
 export function Providers({ children }: { children: React.ReactNode }) {
   const [client] = useState(() => new QueryClient());
-  const locale = usePreferencesStore((state) => state.locale);
-  const setLocale = usePreferencesStore((state) => state.setLocale);
+  const language = usePreferencesStore((state) => state.language);
+  const setLanguage = usePreferencesStore((state) => state.setLanguage);
 
   useEffect(() => {
     const documentLocale = (document.documentElement.lang || DEFAULT_LOCALE) as Locale;
-    if (documentLocale !== locale) {
-      setLocale(documentLocale);
+    if (documentLocale !== language) {
+      setLanguage(documentLocale);
       applyLocaleToDocument(documentLocale);
     }
-  }, [locale, setLocale]);
+  }, [language, setLanguage]);
 
   return (
     <ThemeProvider>
       <QueryClientProvider client={client}>
         {children}
         <ReactQueryDevtools initialIsOpen={false} position="bottom" buttonPosition="bottom-left" />
-        <Toaster position="top-center" richColors dir={locale === "ar" ? "rtl" : "ltr"} />
+        <Toaster position="top-center" richColors dir={language === "ar" ? "rtl" : "ltr"} />
       </QueryClientProvider>
     </ThemeProvider>
   );

--- a/components/admin/appointments-table.tsx
+++ b/components/admin/appointments-table.tsx
@@ -19,11 +19,11 @@ export type AdminAppointment = {
 };
 
 const statusLabels: Record<string, string> = {
-  SCHEDULED: "مجدول",
-  DONE: "منجز",
-  CANCELED: "ملغى",
-  RESCHEDULED: "معاد جدولته",
-  NO_SHOW: "لم يحضر",
+  SCHEDULED: "Scheduled",
+  DONE: "Completed",
+  CANCELED: "Canceled",
+  RESCHEDULED: "Rescheduled",
+  NO_SHOW: "No show",
 };
 
 type Action = "CANCEL" | "CONFIRM_DONE" | "ADD_NOTES" | "RESCHEDULE";
@@ -42,22 +42,25 @@ export function AppointmentsTable({ appointments }: { appointments: AdminAppoint
       });
       if (!response.ok) {
         const message = (await response.json().catch(() => null)) as { error?: string } | null;
-        throw new Error(message?.error ?? "فشل تحديث الموعد");
+        throw new Error(message?.error ?? "Failed to update appointment");
       }
       return response.json();
     },
     onSuccess: () => {
-      toast.success("تم تحديث الموعد");
+      toast.success("Appointment updated");
       window.location.reload();
     },
     onError: (error: unknown) => {
-      toast.error(error instanceof Error ? error.message : "حدث خطأ غير متوقع");
+      toast.error(error instanceof Error ? error.message : "Unexpected error");
     },
   });
 
   const handleAction = (id: string, action: Action) => {
     if (action === "RESCHEDULE") {
-      const newStartAt = window.prompt("اختر تاريخاً جديداً بصيغة YYYY-MM-DDTHH:mm", new Date().toISOString().slice(0, 16));
+      const newStartAt = window.prompt(
+        "Select a new start date in YYYY-MM-DDTHH:mm format",
+        new Date().toISOString().slice(0, 16),
+      );
       if (!newStartAt) return;
       mutation.mutate({ id, action, newStartAt });
       return;
@@ -67,16 +70,16 @@ export function AppointmentsTable({ appointments }: { appointments: AdminAppoint
 
   return (
     <div className="overflow-x-auto rounded-3xl bg-white/80 shadow-soft ring-1 ring-brand-100">
-      <table className="w-full min-w-[720px] text-right text-sm">
+      <table className="w-full min-w-[720px] text-left text-sm">
         <thead className="bg-brand-100/60 text-brand-600">
           <tr>
-            <th className="px-4 py-3 font-medium">المتعلم</th>
-            <th className="px-4 py-3 font-medium">الدورة</th>
-            <th className="px-4 py-3 font-medium">الموضوع</th>
-            <th className="px-4 py-3 font-medium">الوقت</th>
-            <th className="px-4 py-3 font-medium">الحالة</th>
-            <th className="px-4 py-3 font-medium">ملاحظات</th>
-            <th className="px-4 py-3 font-medium">إجراءات</th>
+            <th className="px-4 py-3 font-medium">Learner</th>
+            <th className="px-4 py-3 font-medium">Course</th>
+            <th className="px-4 py-3 font-medium">Topic</th>
+            <th className="px-4 py-3 font-medium">Schedule</th>
+            <th className="px-4 py-3 font-medium">Status</th>
+            <th className="px-4 py-3 font-medium">Notes</th>
+            <th className="px-4 py-3 font-medium">Actions</th>
           </tr>
         </thead>
         <tbody>
@@ -88,7 +91,7 @@ export function AppointmentsTable({ appointments }: { appointments: AdminAppoint
               <td className="px-4 py-3 text-brand-500">
                 <div className="flex flex-col">
                   <span>{formatUTC(appointment.startAt)}</span>
-                  <span className="text-xs text-brand-400">حتى {formatUTC(appointment.endAt, { variant: "time" })}</span>
+                  <span className="text-xs text-brand-400">until {formatUTC(appointment.endAt, { variant: "time" })}</span>
                 </div>
               </td>
               <td className="px-4 py-3">
@@ -100,7 +103,7 @@ export function AppointmentsTable({ appointments }: { appointments: AdminAppoint
                 <Textarea
                   value={notesState[appointment.id] ?? ""}
                   onChange={(event) => setNotesState((state) => ({ ...state, [appointment.id]: event.target.value }))}
-                  placeholder="أضف ملاحظات للمدرب"
+                  placeholder="Add notes for the instructor"
                 />
                 <Button
                   type="button"
@@ -110,7 +113,7 @@ export function AppointmentsTable({ appointments }: { appointments: AdminAppoint
                   onClick={() => handleAction(appointment.id, "ADD_NOTES")}
                   disabled={mutation.isPending}
                 >
-                  حفظ الملاحظات
+                  Save notes
                 </Button>
               </td>
               <td className="px-4 py-3">
@@ -122,7 +125,7 @@ export function AppointmentsTable({ appointments }: { appointments: AdminAppoint
                     onClick={() => handleAction(appointment.id, "RESCHEDULE")}
                     disabled={mutation.isPending}
                   >
-                    إعادة جدولة
+                    Reschedule
                   </Button>
                   <Button
                     type="button"
@@ -131,7 +134,7 @@ export function AppointmentsTable({ appointments }: { appointments: AdminAppoint
                     onClick={() => handleAction(appointment.id, "CONFIRM_DONE")}
                     disabled={mutation.isPending}
                   >
-                    إنهاء الجلسة
+                    Mark as done
                   </Button>
                   <Button
                     type="button"
@@ -141,7 +144,7 @@ export function AppointmentsTable({ appointments }: { appointments: AdminAppoint
                     onClick={() => handleAction(appointment.id, "CANCEL")}
                     disabled={mutation.isPending}
                   >
-                    إلغاء
+                    Cancel
                   </Button>
                 </div>
               </td>

--- a/components/admin/auth/admin-login-form.tsx
+++ b/components/admin/auth/admin-login-form.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { FormEvent, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { signInWithEmailAndPassword } from "firebase/auth";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { getFirebaseClient } from "@/lib/firebase-client";
+
+export function AdminLoginForm() {
+  const router = useRouter();
+  const auth = getFirebaseClient();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [isPending, startTransition] = useTransition();
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    startTransition(async () => {
+      try {
+        const credential = await signInWithEmailAndPassword(auth, email, password);
+        const idToken = await credential.user.getIdToken();
+        const response = await fetch("/api/admin/session", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ idToken }),
+        });
+
+        if (!response.ok) {
+          const message = (await response.json().catch(() => null)) as { error?: string } | null;
+          throw new Error(message?.error ?? "Unable to sign in");
+        }
+
+        toast.success("Welcome back, admin");
+        setEmail("");
+        setPassword("");
+        router.replace("/admin");
+        router.refresh();
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Something went wrong";
+        toast.error(message);
+      }
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="grid gap-2 text-left">
+        <Label htmlFor="admin-email">Work email</Label>
+        <Input
+          id="admin-email"
+          type="email"
+          required
+          autoComplete="email"
+          value={email}
+          onChange={(event) => setEmail(event.target.value)}
+          placeholder="admin@example.com"
+        />
+      </div>
+      <div className="grid gap-2 text-left">
+        <Label htmlFor="admin-password">Password</Label>
+        <Input
+          id="admin-password"
+          type="password"
+          required
+          autoComplete="current-password"
+          value={password}
+          onChange={(event) => setPassword(event.target.value)}
+          placeholder="••••••••"
+        />
+      </div>
+      <Button type="submit" className="w-full" size="lg" disabled={isPending}>
+        {isPending ? "Signing in..." : "Sign in"}
+      </Button>
+    </form>
+  );
+}
+

--- a/components/admin/cash-booking-form.tsx
+++ b/components/admin/cash-booking-form.tsx
@@ -90,16 +90,16 @@ export function CashBookingForm({ courses }: { courses: CashBookingCourse[] }) {
       });
       if (!response.ok) {
         const message = (await response.json().catch(() => null)) as { error?: string } | null;
-        throw new Error(message?.error ?? "فشل إنشاء الحجز النقدي");
+        throw new Error(message?.error ?? "Failed to create cash booking");
       }
       return response.json();
     },
     onSuccess: () => {
-      toast.success("تم إنشاء الحجز النقدي");
+      toast.success("Cash booking created");
       setForm({ ...initialState, courseId: courses[0]?.id, difficultyId: courses[0]?.difficulties[0]?.id });
     },
     onError: (error) => {
-      toast.error(error instanceof Error ? error.message : "حدث خطأ غير متوقع");
+      toast.error(error instanceof Error ? error.message : "Unexpected error");
     },
   });
 
@@ -120,8 +120,8 @@ export function CashBookingForm({ courses }: { courses: CashBookingCourse[] }) {
     return (
       <Card>
         <CardHeader>
-          <CardTitle>لا توجد دورات متاحة للحجز</CardTitle>
-          <CardDescription>أضف الدورات من لوحة التحكم قبل إنشاء حجوزات نقدية.</CardDescription>
+          <CardTitle>No courses available</CardTitle>
+          <CardDescription>Add courses from the dashboard before creating cash bookings.</CardDescription>
         </CardHeader>
       </Card>
     );
@@ -137,7 +137,7 @@ export function CashBookingForm({ courses }: { courses: CashBookingCourse[] }) {
     >
       <div className="grid gap-4 md:grid-cols-2">
         <div className="grid gap-2">
-          <Label htmlFor="userEmail">البريد الإلكتروني</Label>
+          <Label htmlFor="userEmail">Learner email</Label>
           <Input
             id="userEmail"
             type="email"
@@ -148,26 +148,26 @@ export function CashBookingForm({ courses }: { courses: CashBookingCourse[] }) {
           />
         </div>
         <div className="grid gap-2">
-          <Label htmlFor="userName">الاسم الكامل</Label>
+          <Label htmlFor="userName">Full name</Label>
           <Input
             id="userName"
             required
             value={form.userName}
             onChange={(event) => updateField("userName", event.target.value)}
-            placeholder="اسم المتعلم"
+            placeholder="Learner name"
           />
         </div>
         <div className="grid gap-2">
-          <Label htmlFor="userPhone">رقم الهاتف</Label>
+          <Label htmlFor="userPhone">Phone number</Label>
           <Input
             id="userPhone"
             value={form.userPhone}
             onChange={(event) => updateField("userPhone", event.target.value)}
-            placeholder="مثال: +961123456"
+            placeholder="e.g. +961123456"
           />
         </div>
         <div className="grid gap-2">
-          <Label htmlFor="slot">موعد الجلسة الأولى</Label>
+          <Label htmlFor="slot">First session time</Label>
           <Input
             id="slot"
             type="datetime-local"
@@ -180,7 +180,7 @@ export function CashBookingForm({ courses }: { courses: CashBookingCourse[] }) {
 
       <div className="grid gap-4">
         <div className="grid gap-2">
-          <Label>الدورة</Label>
+          <Label>Course</Label>
           <div className="flex flex-wrap gap-2">
             {courses.map((course) => (
               <Button
@@ -195,7 +195,7 @@ export function CashBookingForm({ courses }: { courses: CashBookingCourse[] }) {
           </div>
         </div>
         <div className="grid gap-2">
-          <Label>المستوى</Label>
+          <Label>Difficulty</Label>
           <div className="flex flex-wrap gap-2">
             {selectedCourse?.difficulties.map((difficulty) => (
               <Button
@@ -210,25 +210,24 @@ export function CashBookingForm({ courses }: { courses: CashBookingCourse[] }) {
           </div>
         </div>
         <div className="grid gap-2">
-          <Label>الموضوعات المختارة</Label>
+          <Label>Topics</Label>
           <div className="flex flex-wrap gap-2">
             {topics.map((topic) => (
               <Badge key={topic.id} selected={form.selectedTopics.includes(topic.id)} onClick={() => toggleTopic(topic.id)}>
-                {topic.name} · {topic.sessionsRequired} جلسة
+                {topic.name} · {topic.sessionsRequired} sessions
               </Badge>
             ))}
           </div>
           <p className="text-sm text-brand-500">
-            إجمالي الجلسات: {sessionsTotal} — القيمة المقترحة:
-            {" "}
-            {estimatedAmount.toLocaleString("ar-LB", { style: "currency", currency: form.currency })}
+            Total sessions: {sessionsTotal} — Suggested amount:{" "}
+            {estimatedAmount.toLocaleString("en-US", { style: "currency", currency: form.currency })}
           </p>
         </div>
       </div>
 
       <div className="grid gap-4 md:grid-cols-3">
         <div className="grid gap-2">
-          <Label htmlFor="amount">المبلغ المحصل</Label>
+          <Label htmlFor="amount">Amount collected</Label>
           <Input
             id="amount"
             type="number"
@@ -238,7 +237,7 @@ export function CashBookingForm({ courses }: { courses: CashBookingCourse[] }) {
           />
         </div>
         <div className="grid gap-2">
-          <Label htmlFor="currency">العملة</Label>
+          <Label htmlFor="currency">Currency</Label>
           <Input
             id="currency"
             value={form.currency}
@@ -246,28 +245,28 @@ export function CashBookingForm({ courses }: { courses: CashBookingCourse[] }) {
           />
         </div>
         <div className="grid gap-2">
-          <Label htmlFor="coupon">كوبون (اختياري)</Label>
+          <Label htmlFor="coupon">Coupon (optional)</Label>
           <Input
             id="coupon"
             value={form.couponCode ?? ""}
             onChange={(event) => updateField("couponCode", event.target.value)}
-            placeholder="CODE10"
+            placeholder="SAVE10"
           />
         </div>
       </div>
 
       <div className="grid gap-2">
-        <Label htmlFor="notes">ملاحظات</Label>
+        <Label htmlFor="notes">Notes</Label>
         <Textarea
           id="notes"
           value={form.notes}
           onChange={(event) => updateField("notes", event.target.value)}
-          placeholder="ملاحظات إضافية للمدرب أو المتعلم"
+          placeholder="Additional notes for the instructor or learner"
         />
       </div>
 
       <Button type="submit" size="lg" className="w-full md:w-auto" disabled={mutation.isPending}>
-        {mutation.isPending ? "جاري الإنشاء..." : "إنشاء الحجز"}
+        {mutation.isPending ? "Creating..." : "Create booking"}
       </Button>
     </form>
   );

--- a/components/language-switch.tsx
+++ b/components/language-switch.tsx
@@ -26,15 +26,15 @@ export function LanguageSwitch({ locale, labels }: LanguageSwitchProps) {
   const router = useRouter();
   const pathname = usePathname();
   const [isPending, startTransition] = useTransition();
-  const persistedLocale = usePreferencesStore((state) => state.locale);
-  const setLocale = usePreferencesStore((state) => state.setLocale);
+  const persistedLanguage = usePreferencesStore((state) => state.language);
+  const setLanguage = usePreferencesStore((state) => state.setLanguage);
 
   useEffect(() => {
     const currentDocumentLocale = (document.documentElement.lang || DEFAULT_LOCALE) as Locale;
-    if (SUPPORTED_LOCALES.includes(currentDocumentLocale) && currentDocumentLocale !== persistedLocale) {
-      setLocale(currentDocumentLocale);
+    if (SUPPORTED_LOCALES.includes(currentDocumentLocale) && currentDocumentLocale !== persistedLanguage) {
+      setLanguage(currentDocumentLocale);
     }
-  }, [persistedLocale, setLocale]);
+  }, [persistedLanguage, setLanguage]);
 
   useEffect(() => {
     applyLocaleToDocument(locale);
@@ -46,7 +46,7 @@ export function LanguageSwitch({ locale, labels }: LanguageSwitchProps) {
     }
 
     startTransition(async () => {
-      setLocale(nextLocale);
+      setLanguage(nextLocale);
       applyLocaleToDocument(nextLocale);
 
       await fetch("/api/locale", {

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -1,13 +1,17 @@
 import Link from "next/link";
+import { getCurrentUser } from "@/lib/auth";
 import { getDictionary, getLocale, isRTL } from "@/lib/i18n";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { Button } from "@/components/ui/button";
 import { LanguageSwitch } from "@/components/language-switch";
 
+export const dynamic = "force-dynamic";
+
 export async function Navbar() {
   const locale = await getLocale();
   const dict = await getDictionary(locale);
   const dir = isRTL(locale) ? "rtl" : "ltr";
+  const user = await getCurrentUser();
 
   return (
     <header className="sticky top-0 z-30 w-full border-b border-brand-100/60 bg-sand/80 backdrop-blur-xl dark:bg-brand-900/80">
@@ -27,9 +31,11 @@ export async function Navbar() {
           <Link href="/discovery" className="hover:text-emerald-600">
             {dict.common.discovery}
           </Link>
-          <Link href="/admin" className="hover:text-emerald-600">
-            {dict.common.dashboard}
-          </Link>
+          {user?.role === "ADMIN" && (
+            <Link href="/admin" className="hover:text-emerald-600">
+              {dict.common.dashboard}
+            </Link>
+          )}
         </nav>
         <div className="flex items-center gap-3">
           <LanguageSwitch

--- a/middleware.ts
+++ b/middleware.ts
@@ -14,6 +14,17 @@ export function middleware(request: NextRequest) {
   const segments = pathname.split("/").filter(Boolean);
   const potentialLocale = segments[0] as Locale | undefined;
 
+  if (pathname.startsWith("/admin")) {
+    response.cookies.set({
+      name: LOCALE_COOKIE,
+      value: "en",
+      path: "/",
+      sameSite: "lax",
+      maxAge: 60 * 60 * 24 * 365,
+    });
+    return response;
+  }
+
   if (potentialLocale && SUPPORTED_LOCALES.includes(potentialLocale)) {
     response.cookies.set({
       name: LOCALE_COOKIE,

--- a/stores/preferences.ts
+++ b/stores/preferences.ts
@@ -6,15 +6,15 @@ import { persist, createJSONStorage } from "zustand/middleware";
 import { DEFAULT_LOCALE, type Locale } from "@/lib/i18n-config";
 
 type PreferencesState = {
-  locale: Locale;
-  setLocale: (locale: Locale) => void;
+  language: Locale;
+  setLanguage: (language: Locale) => void;
 };
 
 export const usePreferencesStore = create<PreferencesState>()(
   persist(
     (set) => ({
-      locale: DEFAULT_LOCALE,
-      setLocale: (locale) => set({ locale }),
+      language: DEFAULT_LOCALE,
+      setLanguage: (language) => set({ language }),
     }),
     {
       name: "preferences-store",
@@ -31,7 +31,7 @@ export const usePreferencesStore = create<PreferencesState>()(
         }
         return localStorage;
       }),
-      partialize: (state) => ({ locale: state.locale }),
+      partialize: (state) => ({ language: state.language }),
     },
   ),
 );


### PR DESCRIPTION
## Summary
- Persist the interface preference as a language flag, updating client providers and the language switcher so RTL/LTR and messaging follow Arabic/English toggles without touching routes.
- Require authentication before accessing the booking flow and hide the admin dashboard link from non-admin users.
- Introduce a dedicated English admin login experience with its own API session endpoint, force admin routes to English, and translate admin UI copy into English.

## Testing
- `npm run lint` *(fails: `next` CLI not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d59f6640bc832694701a5feeb42a04