### PR TITLE
Adjust language handling for admin and client

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { redirect } from "next/navigation";
 
+import { AdminLanguageInitializer } from "@/components/admin/admin-language-initializer";
 import { getCurrentUser } from "@/lib/auth";
 import { getDictionary } from "@/lib/i18n";
 import type { Locale } from "@/lib/i18n";
@@ -25,6 +26,7 @@ export default async function AdminLayout({ children }: { children: React.ReactN
 
   return (
     <div className="grid gap-8 lg:grid-cols-[260px_1fr]">
+      <AdminLanguageInitializer />
       <aside className="h-fit rounded-3xl bg-white/80 p-6 shadow-soft ring-1 ring-brand-100">
         <div className="space-y-6">
           <div>

--- a/components/admin/admin-language-initializer.tsx
+++ b/components/admin/admin-language-initializer.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useRouter } from "next/navigation";
+
+import { applyLocaleToDocument } from "@/lib/locale-client";
+import { usePreferencesStore } from "@/stores/preferences";
+
+export function AdminLanguageInitializer() {
+  const router = useRouter();
+  const initializedRef = useRef(false);
+  const language = usePreferencesStore((state) => state.language);
+  const setLanguage = usePreferencesStore((state) => state.setLanguage);
+
+  useEffect(() => {
+    if (initializedRef.current) {
+      return;
+    }
+
+    if (language !== "en") {
+      initializedRef.current = true;
+      setLanguage("en");
+      applyLocaleToDocument("en");
+
+      fetch("/api/locale", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ locale: "en" }),
+      }).finally(() => {
+        router.refresh();
+      });
+    }
+  }, [language, router, setLanguage]);
+
+  return null;
+}
+

--- a/components/language-switch.tsx
+++ b/components/language-switch.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useTransition } from "react";
-import { usePathname, useRouter } from "next/navigation";
+import { useRouter } from "next/navigation";
 
 import { Button } from "@/components/ui/button";
 import { DEFAULT_LOCALE, SUPPORTED_LOCALES, type Locale } from "@/lib/i18n-config";
@@ -24,7 +24,6 @@ const LOCALE_LABEL: Record<Locale, keyof LanguageSwitchProps["labels"]> = {
 
 export function LanguageSwitch({ locale, labels }: LanguageSwitchProps) {
   const router = useRouter();
-  const pathname = usePathname();
   const [isPending, startTransition] = useTransition();
   const persistedLanguage = usePreferencesStore((state) => state.language);
   const setLanguage = usePreferencesStore((state) => state.setLanguage);
@@ -55,12 +54,7 @@ export function LanguageSwitch({ locale, labels }: LanguageSwitchProps) {
         body: JSON.stringify({ locale: nextLocale }),
       });
 
-      const targetPath = resolveTargetPath({ pathname, nextLocale });
-      if (targetPath && targetPath !== pathname) {
-        router.replace(targetPath);
-      } else {
-        router.refresh();
-      }
+      router.refresh();
     });
   };
 
@@ -90,23 +84,3 @@ export function LanguageSwitch({ locale, labels }: LanguageSwitchProps) {
   );
 }
 
-function resolveTargetPath({
-  pathname,
-  nextLocale,
-}: {
-  pathname: string;
-  nextLocale: Locale;
-}) {
-  const segments = pathname.split("/").filter(Boolean);
-  const firstSegment = segments[0];
-
-  if (segments.length === 0) {
-    return nextLocale === DEFAULT_LOCALE ? "/" : `/${nextLocale}`;
-  }
-
-  if (segments.length === 1 && SUPPORTED_LOCALES.includes(firstSegment as Locale)) {
-    return nextLocale === DEFAULT_LOCALE ? "/" : `/${nextLocale}`;
-  }
-
-  return pathname;
-}

--- a/components/navbar-language-switch.tsx
+++ b/components/navbar-language-switch.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useMemo } from "react";
+import { usePathname } from "next/navigation";
+
+import { LanguageSwitch } from "@/components/language-switch";
+import type { Locale } from "@/lib/i18n-config";
+
+type NavbarLanguageSwitchProps = {
+  locale: Locale;
+  labels: {
+    title: string;
+    arabic: string;
+    english: string;
+  };
+};
+
+export function NavbarLanguageSwitch({ locale, labels }: NavbarLanguageSwitchProps) {
+  const pathname = usePathname();
+
+  const shouldRender = useMemo(() => {
+    if (!pathname) {
+      return true;
+    }
+
+    return !pathname.startsWith("/admin");
+  }, [pathname]);
+
+  if (!shouldRender) {
+    return null;
+  }
+
+  return <LanguageSwitch locale={locale} labels={labels} />;
+}
+

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -3,7 +3,7 @@ import { getCurrentUser } from "@/lib/auth";
 import { getDictionary, getLocale, isRTL } from "@/lib/i18n";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { Button } from "@/components/ui/button";
-import { LanguageSwitch } from "@/components/language-switch";
+import { NavbarLanguageSwitch } from "@/components/navbar-language-switch";
 
 export const dynamic = "force-dynamic";
 
@@ -38,7 +38,7 @@ export async function Navbar() {
           )}
         </nav>
         <div className="flex items-center gap-3">
-          <LanguageSwitch
+          <NavbarLanguageSwitch
             locale={locale}
             labels={{
               title: dict.common.language,


### PR DESCRIPTION
## Summary
- ensure the public language switch no longer rewrites URLs by relying solely on state and cookie refreshes
- hide the language switch within the navbar while visiting admin routes
- initialize the admin area in English by default via a client-side locale initializer

## Testing
- npm run lint *(fails: `next` binary missing because dependencies cannot be installed due to peer dependency conflicts)*

------
https://chatgpt.com/codex/tasks/task_e_68d5a826f4348326b6e4f588c685105c