### PR TITLE
Update booking flow, login signup, and course listings

### DIFF
--- a/app/(public)/courses/page.tsx
+++ b/app/(public)/courses/page.tsx
@@ -1,7 +1,6 @@
 import Link from "next/link";
 import type { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/db";
-import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { getLocale, getDictionary } from "@/lib/i18n";
@@ -71,28 +70,24 @@ export default async function CoursesPage() {
               <CardContent className="space-y-4">
                 <div className="space-y-2">
                   <h3 className="text-sm font-semibold text-brand-700">{coursesDict.difficulties.title}</h3>
-                  <div className="flex flex-wrap gap-2">
+                  <div className="grid gap-2 sm:grid-cols-2">
                     {course.difficulties.map((difficulty) => (
-                      <Badge key={difficulty.id}>
-                        {difficulty.label} — {Number(difficulty.pricePerSession).toLocaleString(locale, {
-                          style: "currency",
-                          currency: "USD",
-                        })}
-                      </Badge>
-                    ))}
-                  </div>
-                </div>
-                <div className="space-y-2">
-                  <h3 className="text-sm font-semibold text-brand-700">{coursesDict.topics.title}</h3>
-                  <div className="grid gap-2 text-sm text-brand-600">
-                    {course.topics.map((topic) => (
-                      <div key={topic.id} className="flex items-center justify-between rounded-2xl bg-white/60 px-4 py-2">
-                        <span>{topic.name}</span>
-                        <span className="text-xs text-brand-400">
-                          {coursesDict.topics.metaTemplate
-                            .replace("{{sessions}}", topic.sessionsRequired.toString())
-                            .replace("{{hours}}", topic.estimatedHours.toString())}
-                        </span>
+                      <div
+                        key={difficulty.id}
+                        className="rounded-3xl border border-emerald-200/60 bg-emerald-50/80 px-4 py-3 text-emerald-700 shadow-sm"
+                      >
+                        <p className="text-xs font-semibold uppercase tracking-wide text-emerald-600">
+                          {difficulty.label}
+                        </p>
+                        <p className="mt-1 text-sm font-medium">
+                          {Number(difficulty.pricePerSession).toLocaleString(locale, {
+                            style: "currency",
+                            currency: "USD",
+                          })}{" "}
+                          <span className="text-xs font-normal text-emerald-600">
+                            · {coursesDict.difficulties.priceLabel}
+                          </span>
+                        </p>
                       </div>
                     ))}
                   </div>

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -72,7 +72,8 @@
       "cta": "Open dashboard"
     },
     "difficulties": {
-      "title": "Difficulty levels"
+      "title": "Difficulty levels",
+      "priceLabel": "per session"
     },
     "topics": {
       "title": "Topics",
@@ -129,7 +130,12 @@
       "passwordPlaceholder": "••••••••",
       "submit": "Log in",
       "submitting": "Signing in...",
+      "signup": "Sign up",
+      "signingUp": "Creating account...",
+      "toggleToSignup": "Need an account? Sign up",
+      "toggleToLogin": "Already have an account? Log in",
       "success": "Signed in successfully",
+      "signupSuccess": "Account created successfully",
       "errors": {
         "userSyncFailed": "Failed to persist user details",
         "unexpected": "Something went wrong. Please try again."
@@ -150,13 +156,20 @@
       "DISCOVERY_CALL": "I want a discovery call"
     },
     "form": {
+      "levelCheck": {
+        "title": "Do you know your level?",
+        "description": "Let us know if you're confident about your current level before picking a difficulty.",
+        "knows": "Yes, I know my level",
+        "unsure": "I'm not sure yet"
+      },
       "course": {
         "title": "Choose a course",
         "description": "Select the course that matches your goals."
       },
       "difficulty": {
         "title": "Difficulty",
-        "description": "Pick a level to reveal the session rate."
+        "description": "Pick a level to reveal the session rate.",
+        "priceLabel": "per session"
       },
       "topics": {
         "title": "Topics",

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,4 +1,5 @@
-import { cookies } from "next/headers";
+import { cookies, headers } from "next/headers";
+import { redirect } from "next/navigation";
 import { getFirebaseAdmin } from "./firebase-admin";
 import { prisma } from "./db";
 
@@ -43,6 +44,17 @@ export async function getCurrentUser(): Promise<SessionUser | null> {
       code === "auth/session-cookie-revoked"
     ) {
       cookieStore.delete("session");
+    }
+    const requestHeaders = headers();
+    const currentPath = requestHeaders.get("next-url") ?? "";
+    if (!currentPath.startsWith("/api")) {
+      if (currentPath.startsWith("/admin")) {
+        if (!currentPath.startsWith("/admin/login")) {
+          redirect("/admin/login");
+        }
+      } else if (!currentPath.startsWith("/login")) {
+        redirect("/login");
+      }
     }
     return null;
   }

--- a/lib/types/booking.ts
+++ b/lib/types/booking.ts
@@ -30,6 +30,12 @@ export type BookingDictionary = {
   };
   placementOptions: Record<string, string>;
   form: {
+    levelCheck: {
+      title: string;
+      description: string;
+      knows: string;
+      unsure: string;
+    };
     course: {
       title: string;
       description: string;
@@ -37,6 +43,7 @@ export type BookingDictionary = {
     difficulty: {
       title: string;
       description: string;
+      priceLabel: string;
     };
     topics: {
       title: string;

--- a/stores/booking.ts
+++ b/stores/booking.ts
@@ -6,6 +6,7 @@ type BookingState = {
   courseId?: string;
   difficultyId?: string;
   selectedTopicIds: string[];
+  knowsLevel?: boolean;
   placementChoice: PlacementChoice;
   levelProvided?: string;
   slotStartAt?: string;
@@ -26,7 +27,8 @@ type BookingActions = {
 
 const initialState: BookingState = {
   selectedTopicIds: [],
-  placementChoice: "KNOWN_LEVEL",
+  knowsLevel: undefined,
+  placementChoice: "PLACEMENT_TEST",
 };
 
 export const useBookingStore = create<BookingState & BookingActions>((set, get) => ({


### PR DESCRIPTION
## Summary
- add a know-your-level step and refreshed difficulty UI to the booking form, including price-per-session display and gating topics until a level is chosen
- enable email/password sign-up alongside login with shared session handling and success messaging
- clean up course cards by removing public topic lists and showing difficulty prices inline, while redirecting invalid sessions back to the appropriate login page

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5b3e9d84c8326b116f4a16bd0b449