### PR TITLE
feat: support bilingual courses and admin catalog workflows

### DIFF
--- a/app/(public)/booking/page.tsx
+++ b/app/(public)/booking/page.tsx
@@ -26,12 +26,12 @@ export default async function BookingPage() {
           orderBy: { order: "asc" },
         },
       },
-      orderBy: { title: "asc" },
+      orderBy: { titleEn: "asc" },
     });
     courses = records.map((course) => ({
       id: course.id,
-      title: course.title,
-      description: course.description,
+      title: locale === "ar" ? course.titleAr : course.titleEn,
+      description: locale === "ar" ? course.descriptionAr : course.descriptionEn,
       type: course.type,
       category: course.category,
       difficulties: course.difficulties.map((difficulty) => ({

--- a/app/(public)/courses/page.tsx
+++ b/app/(public)/courses/page.tsx
@@ -28,7 +28,7 @@ export default async function CoursesPage() {
           orderBy: { order: "asc" },
         },
       },
-      orderBy: { title: "asc" },
+      orderBy: { titleEn: "asc" },
     });
   } catch (error) {
     console.error("Failed to load courses", error);
@@ -56,12 +56,15 @@ export default async function CoursesPage() {
           </Card>
         )}
 
-        {courses.map((course) => (
+        {courses.map((course) => {
+          const title = locale === "ar" ? course.titleAr : course.titleEn;
+          const description = locale === "ar" ? course.descriptionAr : course.descriptionEn;
+          return (
           <Card key={course.id} className="flex flex-col justify-between">
             <div className="space-y-4">
               <CardHeader className="space-y-2">
-                <CardTitle className="text-2xl">{course.title}</CardTitle>
-                <CardDescription>{course.description}</CardDescription>
+                <CardTitle className="text-2xl">{title}</CardTitle>
+                <CardDescription>{description}</CardDescription>
                 <div className="flex flex-wrap gap-2 text-xs font-semibold text-emerald-600">
                   <span className="rounded-full bg-emerald-500/10 px-3 py-1">{course.type}</span>
                   <span className="rounded-full bg-brand-500/10 px-3 py-1">{course.category}</span>
@@ -100,7 +103,8 @@ export default async function CoursesPage() {
               </Button>
             </div>
           </Card>
-        ))}
+          );
+        })}
       </div>
     </section>
   );

--- a/app/admin/appointments/page.tsx
+++ b/app/admin/appointments/page.tsx
@@ -1,9 +1,11 @@
 import { prisma } from "@/lib/db";
+import { getLocale } from "@/lib/i18n";
 import { AppointmentsTable, type AdminAppointment } from "@/components/admin/appointments-table";
 
 export const dynamic = "force-dynamic";
 
 export default async function AdminAppointmentsPage() {
+  const locale = await getLocale();
   let appointments: AdminAppointment[] = [];
   try {
     const records = await prisma.appointment.findMany({
@@ -19,7 +21,7 @@ export default async function AdminAppointmentsPage() {
     appointments = records.map((appointment) => ({
       id: appointment.id,
       learner: appointment.user.name ?? appointment.user.email,
-      course: appointment.course.title,
+      course: locale === "ar" ? appointment.course.titleAr : appointment.course.titleEn,
       topic: appointment.topic?.name ?? "—",
       startAt: appointment.startAt.toISOString(),
       endAt: appointment.endAt.toISOString(),

--- a/app/admin/calendar/page.tsx
+++ b/app/admin/calendar/page.tsx
@@ -1,8 +1,7 @@
 import { addMonths, endOfMonth, startOfMonth, subMonths } from "date-fns";
 
 import { prisma } from "@/lib/db";
-import { getDictionary } from "@/lib/i18n";
-import type { Locale } from "@/lib/i18n";
+import { getDictionary, getLocale } from "@/lib/i18n";
 import type { AdminDictionary } from "@/lib/types/admin";
 import { AdminCalendar } from "@/components/admin/calendar/admin-calendar";
 
@@ -21,7 +20,7 @@ type CalendarAppointment = {
 };
 
 export default async function AdminCalendarPage() {
-  const locale: Locale = "en";
+  const locale = await getLocale();
   const dictionary = await getDictionary(locale);
 
   const now = new Date();
@@ -48,7 +47,7 @@ export default async function AdminCalendarPage() {
     appointments = records.map((record) => ({
       id: record.id,
       learner: record.user.name ?? record.user.email,
-      course: record.course.title,
+      course: locale === "ar" ? record.course.titleAr : record.course.titleEn,
       topic: record.topic?.name ?? null,
       startAt: record.startAt.toISOString(),
       endAt: record.endAt.toISOString(),

--- a/app/admin/cash-booking/page.tsx
+++ b/app/admin/cash-booking/page.tsx
@@ -1,10 +1,12 @@
 import { prisma } from "@/lib/db";
+import { getLocale } from "@/lib/i18n";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { CashBookingForm, type CashBookingCourse } from "@/components/admin/cash-booking-form";
 
 export const dynamic = "force-dynamic";
 
 export default async function AdminCashBookingPage() {
+  const locale = await getLocale();
   let courses: CashBookingCourse[] = [];
   try {
     const records = await prisma.course.findMany({
@@ -12,11 +14,11 @@ export default async function AdminCashBookingPage() {
         difficulties: true,
         topics: { orderBy: { order: "asc" } },
       },
-      orderBy: { title: "asc" },
+      orderBy: { titleEn: "asc" },
     });
     courses = records.map((course) => ({
       id: course.id,
-      title: course.title,
+      title: locale === "ar" ? course.titleAr : course.titleEn,
       difficulties: course.difficulties.map((difficulty) => ({
         id: difficulty.id,
         label: difficulty.label,

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -3,8 +3,7 @@ import { redirect } from "next/navigation";
 
 import { AdminLanguageInitializer } from "@/components/admin/admin-language-initializer";
 import { getCurrentUser } from "@/lib/auth";
-import { getDictionary } from "@/lib/i18n";
-import type { Locale } from "@/lib/i18n";
+import { getDictionary, getLocale } from "@/lib/i18n";
 
 export default async function AdminLayout({ children }: { children: React.ReactNode }) {
   const user = await getCurrentUser();
@@ -12,7 +11,7 @@ export default async function AdminLayout({ children }: { children: React.ReactN
     redirect("/admin/login");
   }
 
-  const locale: Locale = "en";
+  const locale = await getLocale();
   const dictionary = await getDictionary(locale);
   const navItems = [
     { href: "/admin", label: dictionary.admin.nav.overview },
@@ -26,7 +25,7 @@ export default async function AdminLayout({ children }: { children: React.ReactN
 
   return (
     <div className="grid gap-8 lg:grid-cols-[260px_1fr]">
-      <AdminLanguageInitializer />
+      <AdminLanguageInitializer locale={locale} />
       <aside className="h-fit rounded-3xl bg-white/80 p-6 shadow-soft ring-1 ring-brand-100">
         <div className="space-y-6">
           <div>

--- a/app/api/appointments/route.ts
+++ b/app/api/appointments/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { Prisma, AppointmentStatus } from "@prisma/client";
 import { prisma } from "@/lib/db";
 import { getCurrentUser } from "@/lib/auth";
+import { getLocale } from "@/lib/i18n";
 
 export const dynamic = "force-dynamic";
 
@@ -31,6 +32,7 @@ export async function GET(request: Request) {
   }
 
   try {
+    const locale = await getLocale();
     const appointments = await prisma.appointment.findMany({
       where,
       include: { course: true, user: true },
@@ -42,7 +44,7 @@ export async function GET(request: Request) {
       startAt: appointment.startAt.toISOString(),
       endAt: appointment.endAt.toISOString(),
       status: appointment.status,
-      course: appointment.course.title,
+      course: locale === "ar" ? appointment.course.titleAr : appointment.course.titleEn,
       learner: appointment.user.name ?? appointment.user.email,
       notes: appointment.teacherNotes,
     }));

--- a/app/api/courses/route.ts
+++ b/app/api/courses/route.ts
@@ -10,7 +10,7 @@ export async function GET() {
         difficulties: true,
         topics: { orderBy: { order: "asc" } },
       },
-      orderBy: { title: "asc" },
+      orderBy: { titleEn: "asc" },
     });
     const payload = courses.map((course) => ({
       ...course,

--- a/components/admin/admin-language-initializer.tsx
+++ b/components/admin/admin-language-initializer.tsx
@@ -1,13 +1,16 @@
 "use client";
 
 import { useEffect, useRef } from "react";
-import { useRouter } from "next/navigation";
 
 import { applyLocaleToDocument } from "@/lib/locale-client";
+import type { Locale } from "@/lib/i18n-config";
 import { usePreferencesStore } from "@/stores/preferences";
 
-export function AdminLanguageInitializer() {
-  const router = useRouter();
+type AdminLanguageInitializerProps = {
+  locale: Locale;
+};
+
+export function AdminLanguageInitializer({ locale }: AdminLanguageInitializerProps) {
   const initializedRef = useRef(false);
   const language = usePreferencesStore((state) => state.language);
   const setLanguage = usePreferencesStore((state) => state.setLanguage);
@@ -17,20 +20,19 @@ export function AdminLanguageInitializer() {
       return;
     }
 
-    if (language !== "en") {
-      initializedRef.current = true;
-      setLanguage("en");
-      applyLocaleToDocument("en");
-
-      fetch("/api/locale", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ locale: "en" }),
-      }).finally(() => {
-        router.refresh();
-      });
+    initializedRef.current = true;
+    if (language !== locale) {
+      setLanguage(locale);
     }
-  }, [language, router, setLanguage]);
+    applyLocaleToDocument(locale);
+  }, [language, locale, setLanguage]);
+
+  useEffect(() => {
+    if (language !== locale) {
+      setLanguage(locale);
+      applyLocaleToDocument(locale);
+    }
+  }, [language, locale, setLanguage]);
 
   return null;
 }

--- a/components/admin/catalog/catalog-manager.tsx
+++ b/components/admin/catalog/catalog-manager.tsx
@@ -1,27 +1,32 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
-import type { AdminCatalogCourse, AdminCatalogDictionary } from "@/lib/types/admin";
+import type { AdminCatalogCourse, AdminCatalogDictionary, TranslatedField } from "@/lib/types/admin";
 
-type CatalogManagerProps = {
-  initialCourses: AdminCatalogCourse[];
-  dictionary: AdminCatalogDictionary;
-  locale: string;
-};
+const COURSES_PER_PAGE = 6;
+const TOPICS_PER_PAGE = 6;
+
+type View = "list" | "course" | "difficulty" | "topics";
 
 type CourseFormState = {
-  title: string;
-  description: string;
+  titleEn: string;
+  titleAr: string;
+  descriptionEn: string;
+  descriptionAr: string;
   category: string;
   type: AdminCatalogCourse["type"];
+};
+
+type DifficultyDraft = {
+  label: AdminCatalogCourse["difficulties"][number]["label"] | "";
+  price: string;
 };
 
 type TopicFormState = {
@@ -30,12 +35,16 @@ type TopicFormState = {
   sessionsRequired: string;
   estimatedHours: string;
   order: string;
-  difficultyId: string;
 };
 
-function formatCurrency(locale: string, value: number) {
-  return value.toLocaleString(locale, { style: "currency", currency: "USD" });
-}
+const DEFAULT_COURSE_FORM: CourseFormState = {
+  titleEn: "",
+  titleAr: "",
+  descriptionEn: "",
+  descriptionAr: "",
+  category: "",
+  type: "PRIVATE",
+};
 
 const DEFAULT_TOPIC_STATE: TopicFormState = {
   name: "",
@@ -43,62 +52,194 @@ const DEFAULT_TOPIC_STATE: TopicFormState = {
   sessionsRequired: "",
   estimatedHours: "",
   order: "",
-  difficultyId: "",
+};
+
+const DEFAULT_DIFFICULTY_DRAFT: DifficultyDraft = {
+  label: "",
+  price: "",
+};
+
+function formatCurrency(locale: string, value: number) {
+  return value.toLocaleString(locale, { style: "currency", currency: "USD" });
+}
+
+function formatTemplate(template: string, replacements: Record<string, string | number>) {
+  return template.replace(/{{(\w+)}}/g, (_, key) => {
+    const replacement = replacements[key];
+    return replacement === undefined ? "" : String(replacement);
+  });
+}
+
+function getLocalized(field: TranslatedField, locale: string) {
+  if (locale in field) {
+    return field[locale as keyof TranslatedField];
+  }
+  return field.en;
+}
+
+function sortTopics(topics: AdminCatalogCourse["topics"]) {
+  return [...topics].sort((a, b) => a.order - b.order);
+}
+
+function normalizeCourse(course: AdminCatalogCourse): AdminCatalogCourse {
+  return {
+    ...course,
+    difficulties: [...course.difficulties].sort((a, b) => a.label.localeCompare(b.label)),
+    topics: sortTopics(course.topics),
+  };
+}
+
+function sortCourses(courses: AdminCatalogCourse[]) {
+  return [...courses].sort((a, b) => a.title.en.localeCompare(b.title.en));
+}
+
+
+type CatalogManagerProps = {
+  initialCourses: AdminCatalogCourse[];
+  dictionary: AdminCatalogDictionary;
+  locale: string;
 };
 
 export function CatalogManager({ initialCourses, dictionary, locale }: CatalogManagerProps) {
-  const [courses, setCourses] = useState(initialCourses);
+  const [courses, setCourses] = useState(() => sortCourses(initialCourses.map((course) => normalizeCourse(course))));
+  const [view, setView] = useState<View>("list");
+  const [activeCourseId, setActiveCourseId] = useState<string | null>(null);
+  const [activeDifficultyId, setActiveDifficultyId] = useState<string | null>(null);
+  const [searchTerm, setSearchTerm] = useState("");
+  const [coursePage, setCoursePage] = useState(1);
+  const [topicPage, setTopicPage] = useState(1);
+  const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [isCreatingCourse, setIsCreatingCourse] = useState(false);
-  const [editingCourseId, setEditingCourseId] = useState<string | null>(null);
-  const [courseForm, setCourseForm] = useState<CourseFormState>({
-    title: "",
-    description: "",
-    category: "",
-    type: "PRIVATE",
-  });
+  const [courseForm, setCourseForm] = useState<CourseFormState>(DEFAULT_COURSE_FORM);
   const [courseEditForm, setCourseEditForm] = useState<Record<string, CourseFormState>>({});
-  const [difficultyForm, setDifficultyForm] = useState<Record<string, { label: string; price: string }>>({});
+  const [editingCourseId, setEditingCourseId] = useState<string | null>(null);
+  const [updatingCourseId, setUpdatingCourseId] = useState<string | null>(null);
+  const [difficultyDrafts, setDifficultyDrafts] = useState<Record<string, DifficultyDraft>>({});
+  const [creatingDifficultyFor, setCreatingDifficultyFor] = useState<string | null>(null);
+  const [updatingDifficultyId, setUpdatingDifficultyId] = useState<string | null>(null);
   const [priceDrafts, setPriceDrafts] = useState<Record<string, string>>(() => {
     const entries: Record<string, string> = {};
     initialCourses.forEach((course) => {
       course.difficulties.forEach((difficulty) => {
-        entries[difficulty.id] = difficulty.pricePerSession.toString();
+        entries[difficulty.id] = String(difficulty.pricePerSession);
       });
     });
     return entries;
   });
   const [topicForm, setTopicForm] = useState<TopicFormState>(DEFAULT_TOPIC_STATE);
-  const [activeTopicCourse, setActiveTopicCourse] = useState<string | null>(null);
-  const [activeTopicDifficulty, setActiveTopicDifficulty] = useState<string | null>(null);
+  const [isTopicFormOpen, setIsTopicFormOpen] = useState(false);
   const [editingTopicId, setEditingTopicId] = useState<string | null>(null);
+  const [updatingTopicId, setUpdatingTopicId] = useState<string | null>(null);
   const [topicEdits, setTopicEdits] = useState<Record<string, TopicFormState>>({});
+  const [isCreatingTopic, setIsCreatingTopic] = useState(false);
 
-  const difficultyLabels = dictionary.difficulty.labels;
+  const filteredCourses = useMemo(() => {
+    const normalized = searchTerm.trim().toLowerCase();
+    if (!normalized) {
+      return courses;
+    }
+    return courses.filter((course) => course.title.en.toLowerCase().includes(normalized));
+  }, [courses, searchTerm]);
+
+  const totalCoursePages = Math.max(1, Math.ceil(filteredCourses.length / COURSES_PER_PAGE));
+  const paginatedCourses = useMemo(() => {
+    const start = (coursePage - 1) * COURSES_PER_PAGE;
+    return filteredCourses.slice(start, start + COURSES_PER_PAGE);
+  }, [filteredCourses, coursePage]);
+
+  useEffect(() => {
+    if (coursePage > totalCoursePages) {
+      setCoursePage(totalCoursePages);
+    }
+  }, [coursePage, totalCoursePages]);
+
+  const activeCourse = activeCourseId ? courses.find((course) => course.id === activeCourseId) ?? null : null;
+  const activeDifficulty = activeCourse && activeDifficultyId ? activeCourse.difficulties.find((difficulty) => difficulty.id === activeDifficultyId) ?? null : null;
+  const topicsForDifficulty = activeCourse && activeDifficulty ? sortTopics(activeCourse.topics.filter((topic) => topic.difficultyId === activeDifficulty.id)) : [];
+  const totalTopicPages = Math.max(1, Math.ceil(topicsForDifficulty.length / TOPICS_PER_PAGE));
+  const paginatedTopics = useMemo(() => {
+    const start = (topicPage - 1) * TOPICS_PER_PAGE;
+    return topicsForDifficulty.slice(start, start + TOPICS_PER_PAGE);
+  }, [topicsForDifficulty, topicPage]);
+
+  useEffect(() => {
+    if (topicPage > totalTopicPages) {
+      setTopicPage(totalTopicPages);
+    }
+  }, [topicPage, totalTopicPages]);
+
+  useEffect(() => {
+    setTopicPage(1);
+    setIsTopicFormOpen(false);
+    setEditingTopicId(null);
+    setTopicForm(DEFAULT_TOPIC_STATE);
+  }, [activeDifficultyId]);
 
   const resetCourseForm = () => {
-    setCourseForm({ title: "", description: "", category: "", type: "PRIVATE" });
+    setCourseForm(DEFAULT_COURSE_FORM);
+  };
+
+  const updateCourseState = (courseId: string, updater: (course: AdminCatalogCourse) => AdminCatalogCourse) => {
+    setCourses((previous) =>
+      sortCourses(
+        previous.map((course) => (course.id === courseId ? normalizeCourse(updater(course)) : course)),
+      ),
+    );
   };
 
   const handleCreateCourse = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+    if (
+      !courseForm.titleEn.trim() ||
+      !courseForm.titleAr.trim() ||
+      !courseForm.descriptionEn.trim() ||
+      !courseForm.descriptionAr.trim() ||
+      !courseForm.category.trim()
+    ) {
+      toast.error(dictionary.feedback.errorGeneric);
+      return;
+    }
+
     setIsCreatingCourse(true);
     try {
       const response = await fetch("/api/admin/courses", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(courseForm),
+        body: JSON.stringify({
+          titleEn: courseForm.titleEn.trim(),
+          titleAr: courseForm.titleAr.trim(),
+          descriptionEn: courseForm.descriptionEn.trim(),
+          descriptionAr: courseForm.descriptionAr.trim(),
+          category: courseForm.category.trim(),
+          type: courseForm.type,
+        }),
       });
       if (!response.ok) {
         throw new Error(dictionary.feedback.errorGeneric);
       }
-      const result = (await response.json()) as { course: AdminCatalogCourse };
-      const newCourse: AdminCatalogCourse = {
-        ...result.course,
+      const data = (await response.json()) as {
+        course: {
+          id: string;
+          titleEn: string;
+          titleAr: string;
+          descriptionEn: string;
+          descriptionAr: string;
+          type: AdminCatalogCourse["type"];
+          category: string;
+        };
+      };
+      const newCourse: AdminCatalogCourse = normalizeCourse({
+        id: data.course.id,
+        title: { en: data.course.titleEn, ar: data.course.titleAr },
+        description: { en: data.course.descriptionEn, ar: data.course.descriptionAr },
+        type: data.course.type,
+        category: data.course.category,
         difficulties: [],
         topics: [],
-      };
-      setCourses((prev) => [...prev, newCourse]);
+      });
+      setCourses((previous) => sortCourses([...previous, newCourse]));
       resetCourseForm();
+      setIsCreateOpen(false);
       toast.success(dictionary.feedback.courseCreated);
     } catch (error) {
       console.error(error);
@@ -110,11 +251,13 @@ export function CatalogManager({ initialCourses, dictionary, locale }: CatalogMa
 
   const startEditingCourse = (course: AdminCatalogCourse) => {
     setEditingCourseId(course.id);
-    setCourseEditForm((prev) => ({
-      ...prev,
+    setCourseEditForm((previous) => ({
+      ...previous,
       [course.id]: {
-        title: course.title,
-        description: course.description,
+        titleEn: course.title.en,
+        titleAr: course.title.ar,
+        descriptionEn: course.description.en,
+        descriptionAr: course.description.ar,
         category: course.category,
         type: course.type,
       },
@@ -124,166 +267,259 @@ export function CatalogManager({ initialCourses, dictionary, locale }: CatalogMa
   const handleUpdateCourse = async (courseId: string) => {
     const form = courseEditForm[courseId];
     if (!form) return;
+    if (
+      !form.titleEn.trim() ||
+      !form.titleAr.trim() ||
+      !form.descriptionEn.trim() ||
+      !form.descriptionAr.trim() ||
+      !form.category.trim()
+    ) {
+      toast.error(dictionary.feedback.errorGeneric);
+      return;
+    }
+
+    setUpdatingCourseId(courseId);
     try {
       const response = await fetch("/api/admin/courses", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ id: courseId, ...form }),
+        body: JSON.stringify({
+          id: courseId,
+          titleEn: form.titleEn.trim(),
+          titleAr: form.titleAr.trim(),
+          descriptionEn: form.descriptionEn.trim(),
+          descriptionAr: form.descriptionAr.trim(),
+          category: form.category.trim(),
+          type: form.type,
+        }),
       });
       if (!response.ok) {
         throw new Error(dictionary.feedback.errorGeneric);
       }
-      const result = (await response.json()) as { course: AdminCatalogCourse };
-      setCourses((prev) =>
-        prev.map((course) =>
-          course.id === courseId
-            ? { ...course, ...result.course, difficulties: course.difficulties, topics: course.topics }
-            : course,
-        ),
-      );
-      toast.success(dictionary.feedback.courseUpdated);
+      const data = (await response.json()) as {
+        course: {
+          id: string;
+          titleEn: string;
+          titleAr: string;
+          descriptionEn: string;
+          descriptionAr: string;
+          type: AdminCatalogCourse["type"];
+          category: string;
+        };
+      };
+      updateCourseState(courseId, (course) => ({
+        ...course,
+        title: { en: data.course.titleEn, ar: data.course.titleAr },
+        description: { en: data.course.descriptionEn, ar: data.course.descriptionAr },
+        category: data.course.category,
+        type: data.course.type,
+      }));
       setEditingCourseId(null);
+      toast.success(dictionary.feedback.courseUpdated);
     } catch (error) {
       console.error(error);
       toast.error(dictionary.feedback.errorGeneric);
+    } finally {
+      setUpdatingCourseId(null);
     }
   };
 
   const handleCreateDifficulty = async (courseId: string) => {
-    const form = difficultyForm[courseId];
-    if (!form || !form.label || !form.price) {
+    const draft = difficultyDrafts[courseId] ?? DEFAULT_DIFFICULTY_DRAFT;
+    if (!draft.label || !draft.price.trim()) {
       toast.error(dictionary.feedback.errorGeneric);
       return;
     }
+
+    const priceValue = Number(draft.price);
+    if (!Number.isFinite(priceValue) || priceValue <= 0) {
+      toast.error(dictionary.feedback.errorGeneric);
+      return;
+    }
+
+    setCreatingDifficultyFor(courseId);
     try {
       const response = await fetch(`/api/admin/courses/${courseId}/difficulties`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ label: form.label, pricePerSession: Number(form.price) }),
+        body: JSON.stringify({
+          label: draft.label,
+          pricePerSession: priceValue,
+        }),
       });
       if (!response.ok) {
         throw new Error(dictionary.feedback.errorGeneric);
       }
-      const result = await response.json();
-      const newDifficulty = {
-        ...result.difficulty,
-        pricePerSession: Number(result.difficulty.pricePerSession),
+      const data = (await response.json()) as {
+        difficulty: {
+          id: string;
+          label: AdminCatalogCourse["difficulties"][number]["label"];
+          pricePerSession: number | string;
+        };
       };
-      setCourses((prev) =>
-        prev.map((course) =>
-          course.id === courseId
-            ? { ...course, difficulties: [...course.difficulties, newDifficulty] }
-            : course,
-        ),
-      );
-      setPriceDrafts((prev) => ({ ...prev, [newDifficulty.id]: String(newDifficulty.pricePerSession) }));
-      setDifficultyForm((prev) => ({ ...prev, [courseId]: { label: "", price: "" } }));
+      const difficulty = {
+        id: data.difficulty.id,
+        label: data.difficulty.label,
+        pricePerSession: Number(data.difficulty.pricePerSession),
+      };
+      updateCourseState(courseId, (course) => ({
+        ...course,
+        difficulties: [...course.difficulties, difficulty],
+      }));
+      setPriceDrafts((previous) => ({ ...previous, [difficulty.id]: String(difficulty.pricePerSession) }));
+      setDifficultyDrafts((previous) => ({ ...previous, [courseId]: DEFAULT_DIFFICULTY_DRAFT }));
       toast.success(dictionary.feedback.difficultyCreated);
     } catch (error) {
       console.error(error);
       toast.error(dictionary.feedback.errorGeneric);
+    } finally {
+      setCreatingDifficultyFor(null);
     }
   };
 
   const handleUpdateDifficulty = async (courseId: string, difficultyId: string) => {
-    const priceDraft = priceDrafts[difficultyId];
-    if (!priceDraft) {
+    const draft = priceDrafts[difficultyId];
+    if (!draft) {
       toast.error(dictionary.feedback.errorGeneric);
       return;
     }
+
+    const priceValue = Number(draft);
+    if (!Number.isFinite(priceValue) || priceValue <= 0) {
+      toast.error(dictionary.feedback.errorGeneric);
+      return;
+    }
+
+    setUpdatingDifficultyId(difficultyId);
     try {
       const response = await fetch(`/api/admin/courses/${courseId}/difficulties`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ difficultyId, pricePerSession: Number(priceDraft) }),
+        body: JSON.stringify({
+          difficultyId,
+          pricePerSession: priceValue,
+        }),
       });
       if (!response.ok) {
         throw new Error(dictionary.feedback.errorGeneric);
       }
-      const result = await response.json();
-      const updated = {
-        ...result.difficulty,
-        pricePerSession: Number(result.difficulty.pricePerSession),
+      const data = (await response.json()) as {
+        difficulty: {
+          id: string;
+          label: AdminCatalogCourse["difficulties"][number]["label"];
+          pricePerSession: number | string;
+        };
       };
-      setCourses((prev) =>
-        prev.map((course) =>
-          course.id === courseId
-            ? {
-                ...course,
-                difficulties: course.difficulties.map((item) => (item.id === difficultyId ? updated : item)),
-              }
-            : course,
-        ),
-      );
+      const difficulty = {
+        id: data.difficulty.id,
+        label: data.difficulty.label,
+        pricePerSession: Number(data.difficulty.pricePerSession),
+      };
+      updateCourseState(courseId, (course) => ({
+        ...course,
+        difficulties: course.difficulties.map((item) => (item.id === difficultyId ? difficulty : item)),
+      }));
       toast.success(dictionary.feedback.difficultyUpdated);
     } catch (error) {
       console.error(error);
       toast.error(dictionary.feedback.errorGeneric);
+    } finally {
+      setUpdatingDifficultyId(null);
     }
   };
 
-  const openTopicForm = (courseId: string, difficultyId: string) => {
-    setActiveTopicCourse(courseId);
-    setActiveTopicDifficulty(difficultyId);
-    setTopicForm({ ...DEFAULT_TOPIC_STATE, difficultyId });
-  };
-
   const handleCreateTopic = async (courseId: string) => {
-    if (!activeTopicDifficulty) return;
-    const body = {
-      ...topicForm,
-      sessionsRequired: Number(topicForm.sessionsRequired),
-      estimatedHours: topicForm.estimatedHours ? Number(topicForm.estimatedHours) : undefined,
-      order: topicForm.order ? Number(topicForm.order) : undefined,
-    };
-
-    if (!body.name || !body.sessionsRequired) {
+    if (!activeDifficultyId) {
+      return;
+    }
+    if (!topicForm.name.trim() || !topicForm.sessionsRequired.trim()) {
       toast.error(dictionary.feedback.errorGeneric);
       return;
     }
 
+    const sessions = Number(topicForm.sessionsRequired);
+    const hours = topicForm.estimatedHours ? Number(topicForm.estimatedHours) : undefined;
+    const order = topicForm.order ? Number(topicForm.order) : undefined;
+
+    if (!Number.isFinite(sessions) || sessions <= 0) {
+      toast.error(dictionary.feedback.errorGeneric);
+      return;
+    }
+    if (hours !== undefined && (!Number.isFinite(hours) || hours <= 0)) {
+      toast.error(dictionary.feedback.errorGeneric);
+      return;
+    }
+    if (order !== undefined && (!Number.isFinite(order) || order <= 0)) {
+      toast.error(dictionary.feedback.errorGeneric);
+      return;
+    }
+
+    setIsCreatingTopic(true);
     try {
       const response = await fetch(`/api/admin/courses/${courseId}/topics`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ ...body, difficultyId: activeTopicDifficulty }),
+        body: JSON.stringify({
+          difficultyId: activeDifficultyId,
+          name: topicForm.name.trim(),
+          description: topicForm.description.trim() || undefined,
+          sessionsRequired: sessions,
+          estimatedHours: hours,
+          order,
+        }),
       });
       if (!response.ok) {
         throw new Error(dictionary.feedback.errorGeneric);
       }
-      const result = await response.json();
-      const topic = {
-        ...result.topic,
-        sessionsRequired: Number(result.topic.sessionsRequired),
-        estimatedHours: Number(result.topic.estimatedHours),
-        order: Number(result.topic.order),
+      const data = (await response.json()) as {
+        topic: {
+          id: string;
+          name: string;
+          description: string | null;
+          sessionsRequired: number | string;
+          estimatedHours: number | string;
+          order: number | string;
+          difficultyId: string;
+        };
       };
-      setCourses((prev) =>
-        prev.map((course) =>
-          course.id === courseId ? { ...course, topics: [...course.topics, topic] } : course,
-        ),
-      );
+      const topic = {
+        id: data.topic.id,
+        name: data.topic.name,
+        description: data.topic.description,
+        sessionsRequired: Number(data.topic.sessionsRequired),
+        estimatedHours: Number(data.topic.estimatedHours),
+        order: Number(data.topic.order),
+        difficultyId: data.topic.difficultyId,
+      };
+      updateCourseState(courseId, (course) => ({
+        ...course,
+        topics: [...course.topics, topic],
+      }));
+      setIsTopicFormOpen(false);
       setTopicForm(DEFAULT_TOPIC_STATE);
-      setActiveTopicCourse(null);
-      setActiveTopicDifficulty(null);
       toast.success(dictionary.feedback.topicCreated);
     } catch (error) {
       console.error(error);
       toast.error(dictionary.feedback.errorGeneric);
+    } finally {
+      setIsCreatingTopic(false);
     }
   };
 
-  const startEditingTopic = (topic: AdminCatalogCourse["topics"][number]) => {
+  const startEditingTopic = (topicId: string) => {
+    const course = activeCourse;
+    if (!course) return;
+    const topic = course.topics.find((item) => item.id === topicId);
+    if (!topic) return;
     setEditingTopicId(topic.id);
-    setTopicEdits((prev) => ({
-      ...prev,
+    setTopicEdits((previous) => ({
+      ...previous,
       [topic.id]: {
         name: topic.name,
         description: topic.description ?? "",
         sessionsRequired: String(topic.sessionsRequired),
         estimatedHours: String(topic.estimatedHours),
         order: String(topic.order),
-        difficultyId: topic.difficultyId,
       },
     }));
   };
@@ -291,63 +527,98 @@ export function CatalogManager({ initialCourses, dictionary, locale }: CatalogMa
   const handleUpdateTopic = async (courseId: string, topicId: string) => {
     const form = topicEdits[topicId];
     if (!form) return;
+    if (!form.name.trim() || !form.sessionsRequired.trim()) {
+      toast.error(dictionary.feedback.errorGeneric);
+      return;
+    }
+
+    const sessions = Number(form.sessionsRequired);
+    const hours = form.estimatedHours ? Number(form.estimatedHours) : undefined;
+    const order = form.order ? Number(form.order) : undefined;
+
+    if (!Number.isFinite(sessions) || sessions <= 0) {
+      toast.error(dictionary.feedback.errorGeneric);
+      return;
+    }
+    if (hours !== undefined && (!Number.isFinite(hours) || hours <= 0)) {
+      toast.error(dictionary.feedback.errorGeneric);
+      return;
+    }
+    if (order !== undefined && (!Number.isFinite(order) || order <= 0)) {
+      toast.error(dictionary.feedback.errorGeneric);
+      return;
+    }
+
+    setUpdatingTopicId(topicId);
     try {
       const response = await fetch(`/api/admin/courses/${courseId}/topics`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           topicId,
-          name: form.name,
-          description: form.description,
-          sessionsRequired: Number(form.sessionsRequired),
-          estimatedHours: Number(form.estimatedHours),
-          order: Number(form.order),
+          name: form.name.trim(),
+          description: form.description.trim() || undefined,
+          sessionsRequired: sessions,
+          estimatedHours: hours,
+          order,
         }),
       });
       if (!response.ok) {
         throw new Error(dictionary.feedback.errorGeneric);
       }
-      const result = await response.json();
-      const updated = {
-        ...result.topic,
-        sessionsRequired: Number(result.topic.sessionsRequired),
-        estimatedHours: Number(result.topic.estimatedHours),
-        order: Number(result.topic.order),
+      const data = (await response.json()) as {
+        topic: {
+          id: string;
+          name: string;
+          description: string | null;
+          sessionsRequired: number | string;
+          estimatedHours: number | string;
+          order: number | string;
+          difficultyId: string;
+        };
       };
-      setCourses((prev) =>
-        prev.map((course) =>
-          course.id === courseId
-            ? {
-                ...course,
-                topics: course.topics.map((topic) => (topic.id === topicId ? updated : topic)),
-              }
-            : course,
-        ),
-      );
+      const topic = {
+        id: data.topic.id,
+        name: data.topic.name,
+        description: data.topic.description,
+        sessionsRequired: Number(data.topic.sessionsRequired),
+        estimatedHours: Number(data.topic.estimatedHours),
+        order: Number(data.topic.order),
+        difficultyId: data.topic.difficultyId,
+      };
+      updateCourseState(courseId, (course) => ({
+        ...course,
+        topics: course.topics.map((item) => (item.id === topicId ? topic : item)),
+      }));
       setEditingTopicId(null);
       toast.success(dictionary.feedback.topicUpdated);
     } catch (error) {
       console.error(error);
       toast.error(dictionary.feedback.errorGeneric);
+    } finally {
+      setUpdatingTopicId(null);
     }
   };
 
-  const handleReorder = async (courseId: string, difficultyId: string, topicId: string, direction: "up" | "down") => {
-    const course = courses.find((item) => item.id === courseId);
-    if (!course) return;
-    const sortedTopics = course.topics
-      .filter((topic) => topic.difficultyId === difficultyId)
-      .sort((a, b) => a.order - b.order);
+  const handleReorderTopic = async (courseId: string, topicId: string, direction: "up" | "down") => {
+    const course = activeCourse;
+    const difficultyId = activeDifficultyId;
+    if (!course || !difficultyId) return;
+
+    const sortedTopics = sortTopics(course.topics.filter((topic) => topic.difficultyId === difficultyId));
     const index = sortedTopics.findIndex((topic) => topic.id === topicId);
     if (index === -1) return;
+
     const targetIndex = direction === "up" ? index - 1 : index + 1;
-    if (targetIndex < 0 || targetIndex >= sortedTopics.length) return;
+    if (targetIndex < 0 || targetIndex >= sortedTopics.length) {
+      return;
+    }
 
     const current = sortedTopics[index];
     const swapWith = sortedTopics[targetIndex];
 
     try {
-      const swapRequests = [
+      const responses = await Promise.all([
         fetch(`/api/admin/courses/${courseId}/topics`, {
           method: "PATCH",
           headers: { "Content-Type": "application/json" },
@@ -358,29 +629,22 @@ export function CatalogManager({ initialCourses, dictionary, locale }: CatalogMa
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ topicId: swapWith.id, order: current.order }),
         }),
-      ];
-      const responses = await Promise.all(swapRequests);
-      if (responses.some((res) => !res.ok)) {
+      ]);
+      if (responses.some((response) => !response.ok)) {
         throw new Error(dictionary.feedback.errorGeneric);
       }
-      setCourses((prev) =>
-        prev.map((item) =>
-          item.id === courseId
-            ? {
-                ...item,
-                topics: item.topics.map((topic) => {
-                  if (topic.id === current.id) {
-                    return { ...topic, order: swapWith.order };
-                  }
-                  if (topic.id === swapWith.id) {
-                    return { ...topic, order: current.order };
-                  }
-                  return topic;
-                }),
-              }
-            : item,
-        ),
-      );
+      updateCourseState(courseId, (item) => ({
+        ...item,
+        topics: item.topics.map((topic) => {
+          if (topic.id === current.id) {
+            return { ...topic, order: swapWith.order };
+          }
+          if (topic.id === swapWith.id) {
+            return { ...topic, order: current.order };
+          }
+          return topic;
+        }),
+      }));
       toast.success(dictionary.feedback.reorderSuccess);
     } catch (error) {
       console.error(error);
@@ -388,543 +652,871 @@ export function CatalogManager({ initialCourses, dictionary, locale }: CatalogMa
     }
   };
 
-  const courseCards = useMemo(
-    () =>
-      courses.map((course) => {
-        const isEditing = editingCourseId === course.id;
-        const editForm = courseEditForm[course.id];
-        const courseDifficulties = course.difficulties.sort((a, b) => a.label.localeCompare(b.label));
-        const topicsByDifficulty = course.difficulties.reduce<Record<string, AdminCatalogCourse["topics"]>>(
-          (acc, difficulty) => {
-            acc[difficulty.id] = course.topics
-              .filter((topic) => topic.difficultyId === difficulty.id)
-              .sort((a, b) => a.order - b.order);
-            return acc;
-          },
-          {},
-        );
+  const handleViewCourse = (courseId: string) => {
+    setActiveCourseId(courseId);
+    setView("course");
+    setIsCreateOpen(false);
+    setEditingCourseId(null);
+  };
 
-        return (
-          <Card key={course.id} className="rounded-3xl border-brand-100 bg-white/90">
-            <CardHeader className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-              <div className="space-y-2">
-                <CardTitle className="text-2xl text-brand-800">{course.title}</CardTitle>
-                <CardDescription>{course.description}</CardDescription>
-                <div className="flex flex-wrap gap-3 text-xs text-brand-500">
-                  <span className="rounded-full bg-brand-100 px-3 py-1">
-                    {dictionary.courseMeta.type}: {dictionary.createCourse.typeOptions[course.type]}
-                  </span>
-                  <span className="rounded-full bg-brand-100 px-3 py-1">
-                    {dictionary.courseMeta.category}: {course.category}
-                  </span>
+  const handleBackToList = () => {
+    setView("list");
+    setActiveCourseId(null);
+    setActiveDifficultyId(null);
+    setEditingCourseId(null);
+    setIsTopicFormOpen(false);
+    setEditingTopicId(null);
+    setTopicPage(1);
+  };
+
+  const handleBackToCourse = () => {
+    setView("course");
+    setActiveDifficultyId(null);
+    setIsTopicFormOpen(false);
+    setEditingTopicId(null);
+    setTopicPage(1);
+  };
+
+  const handleBackToDifficulties = () => {
+    setView("difficulty");
+    setIsTopicFormOpen(false);
+    setEditingTopicId(null);
+    setTopicPage(1);
+  };
+
+  const renderCourseList = () => {
+    return (
+      <section className="space-y-6">
+        <div className="rounded-3xl bg-white/80 p-6 shadow-soft ring-1 ring-brand-100">
+          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div className="space-y-2">
+              <h2 className="font-display text-2xl text-brand-800">{dictionary.title}</h2>
+              <p className="text-sm text-brand-600">{dictionary.description}</p>
+            </div>
+            <Button type="button" onClick={() => setIsCreateOpen((value) => !value)}>
+              {dictionary.list.addAction}
+            </Button>
+          </div>
+
+          {isCreateOpen && (
+            <form className="mt-6 space-y-6" onSubmit={handleCreateCourse}>
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="grid gap-2">
+                  <Label htmlFor="titleEn">{dictionary.forms.nameEnLabel}</Label>
+                  <Input
+                    id="titleEn"
+                    value={courseForm.titleEn}
+                    onChange={(event) => setCourseForm((previous) => ({ ...previous, titleEn: event.target.value }))}
+                  />
+                </div>
+                <div className="grid gap-2">
+                  <Label htmlFor="titleAr">{dictionary.forms.nameArLabel}</Label>
+                  <Input
+                    id="titleAr"
+                    value={courseForm.titleAr}
+                    onChange={(event) => setCourseForm((previous) => ({ ...previous, titleAr: event.target.value }))}
+                  />
+                </div>
+                <div className="grid gap-2 md:col-span-2">
+                  <Label htmlFor="descriptionEn">{dictionary.forms.descriptionEnLabel}</Label>
+                  <Textarea
+                    id="descriptionEn"
+                    value={courseForm.descriptionEn}
+                    onChange={(event) =>
+                      setCourseForm((previous) => ({ ...previous, descriptionEn: event.target.value }))
+                    }
+                  />
+                </div>
+                <div className="grid gap-2 md:col-span-2">
+                  <Label htmlFor="descriptionAr">{dictionary.forms.descriptionArLabel}</Label>
+                  <Textarea
+                    id="descriptionAr"
+                    value={courseForm.descriptionAr}
+                    onChange={(event) =>
+                      setCourseForm((previous) => ({ ...previous, descriptionAr: event.target.value }))
+                    }
+                  />
+                </div>
+                <div className="grid gap-2">
+                  <Label htmlFor="category">{dictionary.forms.categoryLabel}</Label>
+                  <Input
+                    id="category"
+                    value={courseForm.category}
+                    onChange={(event) => setCourseForm((previous) => ({ ...previous, category: event.target.value }))}
+                  />
+                </div>
+                <div className="grid gap-2">
+                  <Label>{dictionary.forms.typeLabel}</Label>
+                  <div className="flex flex-wrap gap-2">
+                    {Object.entries(dictionary.forms.typeOptions).map(([value, label]) => (
+                      <Button
+                        key={value}
+                        type="button"
+                        variant={courseForm.type === value ? "default" : "outline"}
+                        onClick={() => setCourseForm((previous) => ({ ...previous, type: value as AdminCatalogCourse["type"] }))}
+                      >
+                        {label}
+                      </Button>
+                    ))}
+                  </div>
                 </div>
               </div>
-              <div className="flex gap-2">
-                {isEditing ? (
-                  <>
-                    <Button variant="outline" onClick={() => setEditingCourseId(null)}>
-                      {dictionary.updateCourse.cancelAction}
-                    </Button>
-                    <Button onClick={() => handleUpdateCourse(course.id)}>{dictionary.updateCourse.saveAction}</Button>
-                  </>
-                ) : (
-                  <Button variant="outline" onClick={() => startEditingCourse(course)}>
-                    {dictionary.updateCourse.editAction}
-                  </Button>
-                )}
-              </div>
-            </CardHeader>
-            <CardContent className="space-y-8">
-              {isEditing && editForm && (
-                <form
-                  className="grid gap-4 rounded-2xl border border-dashed border-brand-200 p-4"
-                  onSubmit={(event) => {
-                    event.preventDefault();
-                    handleUpdateCourse(course.id);
+              <div className="flex flex-wrap gap-3">
+                <Button type="submit" disabled={isCreatingCourse}>
+                  {dictionary.forms.submit}
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => {
+                    setIsCreateOpen(false);
+                    resetCourseForm();
                   }}
                 >
-                  <div className="grid gap-2">
-                    <Label htmlFor={`title-${course.id}`}>{dictionary.createCourse.nameLabel}</Label>
-                    <Input
-                      id={`title-${course.id}`}
-                      value={editForm.title}
-                      onChange={(event) =>
-                        setCourseEditForm((prev) => ({
-                          ...prev,
-                          [course.id]: { ...prev[course.id], title: event.target.value },
-                        }))
-                      }
-                    />
-                  </div>
-                  <div className="grid gap-2">
-                    <Label htmlFor={`description-${course.id}`}>{dictionary.createCourse.descriptionLabel}</Label>
-                    <Textarea
-                      id={`description-${course.id}`}
-                      value={editForm.description}
-                      onChange={(event) =>
-                        setCourseEditForm((prev) => ({
-                          ...prev,
-                          [course.id]: { ...prev[course.id], description: event.target.value },
-                        }))
-                      }
-                    />
-                  </div>
-                  <div className="grid gap-2">
-                    <Label htmlFor={`category-${course.id}`}>{dictionary.createCourse.categoryLabel}</Label>
-                    <Input
-                      id={`category-${course.id}`}
-                      value={editForm.category}
-                      onChange={(event) =>
-                        setCourseEditForm((prev) => ({
-                          ...prev,
-                          [course.id]: { ...prev[course.id], category: event.target.value },
-                        }))
-                      }
-                    />
-                  </div>
-                  <div className="grid gap-2">
-                    <Label>{dictionary.createCourse.typeLabel}</Label>
-                    <div className="flex gap-2">
-                      {Object.entries(dictionary.createCourse.typeOptions).map(([value, label]) => (
-                        <Button
-                          key={value}
-                          type="button"
-                          variant={editForm.type === value ? "default" : "outline"}
-                          onClick={() =>
-                            setCourseEditForm((prev) => ({
-                              ...prev,
-                              [course.id]: { ...prev[course.id], type: value as AdminCatalogCourse["type"] },
-                            }))
-                          }
-                        >
-                          {label}
-                        </Button>
-                      ))}
-                    </div>
-                  </div>
-                </form>
-              )}
+                  {dictionary.forms.cancel}
+                </Button>
+              </div>
+            </form>
+          )}
+        </div>
 
-              <section className="space-y-4">
-                <h3 className="font-display text-xl text-brand-800">{dictionary.difficulty.title}</h3>
-                <p className="text-sm text-brand-500">{dictionary.difficulty.existingTitle}</p>
-                <div className="space-y-3">
-                  {courseDifficulties.map((difficulty) => (
-                    <div
-                      key={difficulty.id}
-                      className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-brand-100 bg-white p-4"
-                    >
-                      <div className="space-y-1">
-                        <p className="font-semibold text-brand-700">
-                          {difficultyLabels[difficulty.label] ?? difficulty.label}
-                        </p>
-                        <p className="text-xs text-brand-400">
-                          {dictionary.table.perSession}: {formatCurrency(locale, difficulty.pricePerSession)}
-                        </p>
-                      </div>
-                      <div className="flex items-center gap-2">
-                        <Input
-                          type="number"
-                          min="0"
-                          step="0.5"
-                          value={priceDrafts[difficulty.id] ?? ""}
-                          onChange={(event) =>
-                            setPriceDrafts((prev) => ({ ...prev, [difficulty.id]: event.target.value }))
-                          }
-                        />
-                        <Button onClick={() => handleUpdateDifficulty(course.id, difficulty.id)}>
-                          {dictionary.updateCourse.saveAction}
-                        </Button>
-                      </div>
+        <div className="rounded-3xl bg-white/80 p-6 shadow-soft ring-1 ring-brand-100">
+          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <Input
+              placeholder={dictionary.list.searchPlaceholder}
+              value={searchTerm}
+              onChange={(event) => {
+                setSearchTerm(event.target.value);
+                setCoursePage(1);
+              }}
+            />
+            <div className="flex flex-wrap items-center justify-between gap-3 md:justify-end">
+              <span className="text-sm text-brand-500">
+                {formatTemplate(dictionary.list.pageLabel, { current: coursePage, total: totalCoursePages })}
+              </span>
+              <div className="flex gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => setCoursePage((page) => Math.max(1, page - 1))}
+                  disabled={coursePage === 1}
+                >
+                  <span aria-hidden>‹</span>
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => setCoursePage((page) => Math.min(totalCoursePages, page + 1))}
+                  disabled={coursePage === totalCoursePages}
+                >
+                  <span aria-hidden>›</span>
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {paginatedCourses.length === 0 ? (
+          <Card className="rounded-3xl border-dashed border-brand-200 bg-white/70 text-center">
+            <CardHeader>
+              <CardTitle>{dictionary.list.emptyTitle}</CardTitle>
+              <CardDescription>{dictionary.list.emptyDescription}</CardDescription>
+            </CardHeader>
+          </Card>
+        ) : (
+          <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+            {paginatedCourses.map((course) => {
+              const localizedTitle = getLocalized(course.title, locale);
+              const localizedDescription = getLocalized(course.description, locale);
+              return (
+                <Card key={course.id} className="flex h-full flex-col justify-between rounded-3xl border-brand-100 bg-white/90">
+                  <CardHeader className="space-y-3">
+                    <div>
+                      <CardTitle className="text-xl text-brand-800">{localizedTitle}</CardTitle>
+                      <CardDescription>{localizedDescription}</CardDescription>
                     </div>
-                  ))}
+                    <div className="flex flex-wrap gap-2 text-xs text-brand-500">
+                      <span className="rounded-full bg-brand-100 px-3 py-1">
+                        {dictionary.courseMeta.type}: {dictionary.forms.typeOptions[course.type]}
+                      </span>
+                      <span className="rounded-full bg-brand-100 px-3 py-1">
+                        {dictionary.courseMeta.category}: {course.category}
+                      </span>
+                    </div>
+                  </CardHeader>
+                  <CardContent className="space-y-4">
+                    <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-brand-500">
+                      <span>
+                        {formatTemplate(dictionary.courseDetail.difficultiesCountLabel, {
+                          count: course.difficulties.length,
+                        })}
+                      </span>
+                      <span>
+                        {formatTemplate(dictionary.courseDetail.topicsCountLabel, {
+                          count: course.topics.length,
+                        })}
+                      </span>
+                    </div>
+                    <Button type="button" className="w-full" onClick={() => handleViewCourse(course.id)}>
+                      {dictionary.list.viewAction}
+                    </Button>
+                  </CardContent>
+                </Card>
+              );
+            })}
+          </div>
+        )}
+      </section>
+    );
+  };
+
+  const renderCourseDetail = () => {
+    if (!activeCourse) {
+      return null;
+    }
+
+    const editForm = courseEditForm[activeCourse.id];
+    const difficultySummary = activeCourse.difficulties.map((difficulty) => ({
+      ...difficulty,
+      topicsCount: activeCourse.topics.filter((topic) => topic.difficultyId === difficulty.id).length,
+    }));
+
+    return (
+      <section className="space-y-6">
+        <div className="flex flex-wrap gap-3">
+          <Button type="button" variant="outline" onClick={handleBackToList}>
+            {dictionary.courseDetail.backToList}
+          </Button>
+        </div>
+
+        <div className="rounded-3xl bg-white/80 p-6 shadow-soft ring-1 ring-brand-100">
+          <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+            <div className="space-y-2">
+              <h2 className="font-display text-3xl text-brand-800">{getLocalized(activeCourse.title, locale)}</h2>
+              <p className="text-sm text-brand-600">{dictionary.courseDetail.overviewTitle}</p>
+            </div>
+            {editingCourseId === activeCourse.id ? (
+              <div className="flex gap-2">
+                <Button type="button" variant="outline" onClick={() => setEditingCourseId(null)}>
+                  {dictionary.courseDetail.cancelAction}
+                </Button>
+                <Button type="button" onClick={() => handleUpdateCourse(activeCourse.id)} disabled={updatingCourseId === activeCourse.id}>
+                  {dictionary.courseDetail.saveAction}
+                </Button>
+              </div>
+            ) : (
+              <Button type="button" variant="outline" onClick={() => startEditingCourse(activeCourse)}>
+                {dictionary.courseDetail.editAction}
+              </Button>
+            )}
+          </div>
+
+          {editingCourseId === activeCourse.id && editForm ? (
+            <form
+              className="mt-6 space-y-6"
+              onSubmit={(event) => {
+                event.preventDefault();
+                handleUpdateCourse(activeCourse.id);
+              }}
+            >
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="grid gap-2">
+                  <Label htmlFor="editTitleEn">{dictionary.forms.nameEnLabel}</Label>
+                  <Input
+                    id="editTitleEn"
+                    value={editForm.titleEn}
+                    onChange={(event) =>
+                      setCourseEditForm((previous) => ({
+                        ...previous,
+                        [activeCourse.id]: { ...previous[activeCourse.id], titleEn: event.target.value },
+                      }))
+                    }
+                  />
                 </div>
-                <div className="rounded-2xl border border-dashed border-brand-200 p-4">
-                  <h4 className="font-semibold text-brand-700">{dictionary.difficulty.addTitle}</h4>
-                  <div className="mt-3 grid gap-3 md:grid-cols-[240px_1fr_auto]">
-                    <div className="grid gap-2">
-                      <Label>{dictionary.difficulty.labelPlaceholder}</Label>
-                      <select
-                        className="rounded-2xl border border-brand-200 bg-white px-3 py-2"
-                        value={difficultyForm[course.id]?.label ?? ""}
-                        onChange={(event) =>
-                          setDifficultyForm((prev) => ({
-                            ...prev,
-                            [course.id]: {
-                              ...(prev[course.id] ?? { label: "", price: "" }),
-                              label: event.target.value,
-                            },
+                <div className="grid gap-2">
+                  <Label htmlFor="editTitleAr">{dictionary.forms.nameArLabel}</Label>
+                  <Input
+                    id="editTitleAr"
+                    value={editForm.titleAr}
+                    onChange={(event) =>
+                      setCourseEditForm((previous) => ({
+                        ...previous,
+                        [activeCourse.id]: { ...previous[activeCourse.id], titleAr: event.target.value },
+                      }))
+                    }
+                  />
+                </div>
+                <div className="grid gap-2 md:col-span-2">
+                  <Label htmlFor="editDescriptionEn">{dictionary.forms.descriptionEnLabel}</Label>
+                  <Textarea
+                    id="editDescriptionEn"
+                    value={editForm.descriptionEn}
+                    onChange={(event) =>
+                      setCourseEditForm((previous) => ({
+                        ...previous,
+                        [activeCourse.id]: { ...previous[activeCourse.id], descriptionEn: event.target.value },
+                      }))
+                    }
+                  />
+                </div>
+                <div className="grid gap-2 md:col-span-2">
+                  <Label htmlFor="editDescriptionAr">{dictionary.forms.descriptionArLabel}</Label>
+                  <Textarea
+                    id="editDescriptionAr"
+                    value={editForm.descriptionAr}
+                    onChange={(event) =>
+                      setCourseEditForm((previous) => ({
+                        ...previous,
+                        [activeCourse.id]: { ...previous[activeCourse.id], descriptionAr: event.target.value },
+                      }))
+                    }
+                  />
+                </div>
+                <div className="grid gap-2">
+                  <Label htmlFor="editCategory">{dictionary.forms.categoryLabel}</Label>
+                  <Input
+                    id="editCategory"
+                    value={editForm.category}
+                    onChange={(event) =>
+                      setCourseEditForm((previous) => ({
+                        ...previous,
+                        [activeCourse.id]: { ...previous[activeCourse.id], category: event.target.value },
+                      }))
+                    }
+                  />
+                </div>
+                <div className="grid gap-2">
+                  <Label>{dictionary.forms.typeLabel}</Label>
+                  <div className="flex flex-wrap gap-2">
+                    {Object.entries(dictionary.forms.typeOptions).map(([value, label]) => (
+                      <Button
+                        key={value}
+                        type="button"
+                        variant={editForm.type === value ? "default" : "outline"}
+                        onClick={() =>
+                          setCourseEditForm((previous) => ({
+                            ...previous,
+                            [activeCourse.id]: { ...previous[activeCourse.id], type: value as AdminCatalogCourse["type"] },
                           }))
                         }
                       >
-                        <option value="" disabled>
-                          --
-                        </option>
-                        {Object.entries(difficultyLabels)
-                          .filter(([value]) => !course.difficulties.some((item) => item.label === value))
-                          .map(([value, label]) => (
-                            <option key={value} value={value}>
-                              {label}
-                            </option>
-                          ))}
-                      </select>
-                    </div>
-                    <div className="grid gap-2">
-                      <Label>{dictionary.difficulty.priceLabel}</Label>
-                      <Input
-                        type="number"
-                        min="0"
-                        step="0.5"
-                        value={difficultyForm[course.id]?.price ?? ""}
-                        onChange={(event) =>
-                          setDifficultyForm((prev) => ({
-                            ...prev,
-                            [course.id]: {
-                              ...(prev[course.id] ?? { label: "", price: "" }),
-                              price: event.target.value,
-                            },
-                          }))
-                        }
-                        placeholder={dictionary.difficulty.pricePlaceholder}
-                      />
-                    </div>
-                    <div className="flex items-end">
-                      <Button onClick={() => handleCreateDifficulty(course.id)}>{dictionary.difficulty.submit}</Button>
-                    </div>
+                        {label}
+                      </Button>
+                    ))}
                   </div>
                 </div>
-              </section>
+              </div>
+            </form>
+          ) : (
+            <div className="mt-6 space-y-4">
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="rounded-2xl bg-brand-50/60 p-4">
+                  <p className="text-xs font-medium uppercase tracking-wide text-brand-500">
+                    {dictionary.courseDetail.englishHeading}
+                  </p>
+                  <p className="mt-2 text-brand-800">{activeCourse.title.en}</p>
+                  <p className="mt-2 text-sm text-brand-600">{activeCourse.description.en}</p>
+                </div>
+                <div className="rounded-2xl bg-brand-50/60 p-4">
+                  <p className="text-xs font-medium uppercase tracking-wide text-brand-500">
+                    {dictionary.courseDetail.arabicHeading}
+                  </p>
+                  <p className="mt-2 text-brand-800">{activeCourse.title.ar}</p>
+                  <p className="mt-2 text-sm text-brand-600">{activeCourse.description.ar}</p>
+                </div>
+              </div>
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="rounded-2xl border border-brand-100 bg-white p-4">
+                  <p className="text-xs font-medium uppercase tracking-wide text-brand-500">
+                    {dictionary.courseDetail.metadataTitle}
+                  </p>
+                  <div className="mt-2 space-y-1 text-sm text-brand-600">
+                    <p>
+                      {dictionary.courseDetail.typeLabel}: {dictionary.forms.typeOptions[activeCourse.type]}
+                    </p>
+                    <p>
+                      {dictionary.courseDetail.categoryLabel}: {activeCourse.category}
+                    </p>
+                  </div>
+                </div>
+                <div className="rounded-2xl border border-brand-100 bg-white p-4">
+                  <p className="text-xs font-medium uppercase tracking-wide text-brand-500">
+                    {dictionary.courseDetail.summaryTitle}
+                  </p>
+                  <div className="mt-2 space-y-1 text-sm text-brand-600">
+                    <p>
+                      {formatTemplate(dictionary.courseDetail.difficultiesCountLabel, {
+                        count: activeCourse.difficulties.length,
+                      })}
+                    </p>
+                    <p>
+                      {formatTemplate(dictionary.courseDetail.topicsCountLabel, {
+                        count: activeCourse.topics.length,
+                      })}
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
 
-              <section className="space-y-4">
-                <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-                  <h3 className="font-display text-xl text-brand-800">{dictionary.topics.title}</h3>
-                  <Button
-                    variant="outline"
-                    onClick={() => openTopicForm(course.id, course.difficulties[0]?.id ?? "")}
-                    disabled={!course.difficulties.length}
+        <div className="rounded-3xl bg-white/80 p-6 shadow-soft ring-1 ring-brand-100">
+          <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+            <div>
+              <h3 className="font-display text-xl text-brand-800">{dictionary.courseDetail.summaryTitle}</h3>
+              <p className="text-sm text-brand-600">{dictionary.courseDetail.summaryDescription}</p>
+            </div>
+            <Button type="button" onClick={() => setView("difficulty")}>
+              {dictionary.courseDetail.manageDifficulties}
+            </Button>
+          </div>
+          <div className="mt-6 space-y-4">
+            {difficultySummary.length === 0 ? (
+              <p className="text-sm text-brand-500">{dictionary.difficulty.empty}</p>
+            ) : (
+              difficultySummary.map((difficulty) => (
+                <div
+                  key={difficulty.id}
+                  className="flex flex-col gap-3 rounded-2xl border border-brand-100 bg-white/90 p-4 md:flex-row md:items-center md:justify-between"
+                >
+                  <div className="space-y-1">
+                    <p className="font-semibold text-brand-700">
+                      {dictionary.difficulty.labels[difficulty.label] ?? difficulty.label}
+                    </p>
+                    <p className="text-sm text-brand-500">
+                      {formatCurrency(locale, difficulty.pricePerSession)} · {dictionary.table.perSession}
+                    </p>
+                  </div>
+                  <div className="text-sm text-brand-500">
+                    {formatTemplate(dictionary.courseDetail.topicsCountLabel, {
+                      count: difficulty.topicsCount,
+                    })}
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      </section>
+    );
+  };
+
+  const renderDifficultyView = () => {
+    if (!activeCourse) {
+      return null;
+    }
+    const draft = difficultyDrafts[activeCourse.id] ?? DEFAULT_DIFFICULTY_DRAFT;
+
+    return (
+      <section className="space-y-6">
+        <div className="flex flex-wrap gap-3">
+          <Button type="button" variant="outline" onClick={handleBackToCourse}>
+            {dictionary.difficulty.backToCourse}
+          </Button>
+        </div>
+
+        <div className="rounded-3xl bg-white/80 p-6 shadow-soft ring-1 ring-brand-100">
+          <div className="space-y-3">
+            <h2 className="font-display text-2xl text-brand-800">{dictionary.difficulty.title}</h2>
+            <p className="text-sm text-brand-600">{dictionary.difficulty.description}</p>
+          </div>
+
+          <div className="mt-6 grid gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
+            <div className="space-y-4">
+              <h3 className="font-semibold text-brand-700">{dictionary.difficulty.existingTitle}</h3>
+              {activeCourse.difficulties.length === 0 ? (
+                <p className="text-sm text-brand-500">{dictionary.difficulty.empty}</p>
+              ) : (
+                activeCourse.difficulties.map((difficulty) => (
+                  <div
+                    key={difficulty.id}
+                    className="flex flex-col gap-4 rounded-2xl border border-brand-100 bg-white/90 p-4 md:flex-row md:items-center md:justify-between"
                   >
-                    {dictionary.topics.addButton}
-                  </Button>
-                </div>
-                {!course.topics.length && (
-                  <p className="text-sm text-brand-500">{dictionary.topics.empty}</p>
-                )}
-                <div className="space-y-4">
-                  {course.difficulties.map((difficulty) => {
-                    const topics = topicsByDifficulty[difficulty.id] ?? [];
-                    return (
-                      <div key={difficulty.id} className="space-y-3">
-                        <div className="flex items-center justify-between">
-                          <h4 className="text-lg font-semibold text-brand-700">
-                            {difficultyLabels[difficulty.label] ?? difficulty.label}
-                          </h4>
-                          <Button
-                            variant="ghost"
-                            className="text-sm text-emerald-700 hover:bg-emerald-500/10"
-                            onClick={() => openTopicForm(course.id, difficulty.id)}
-                          >
-                            {dictionary.topics.addButton}
-                          </Button>
-                        </div>
-                        <div className="space-y-2">
-                          {topics.map((topic) => {
-                            const isEditingTopic = editingTopicId === topic.id;
-                            const topicFormState = topicEdits[topic.id];
-                            return (
-                              <div
-                                key={topic.id}
-                                className="rounded-2xl border border-brand-100 bg-white p-4"
-                              >
-                                <div className="flex flex-wrap items-center justify-between gap-3">
-                                  <div>
-                                    <p className="font-semibold text-brand-800">{topic.name}</p>
-                                    <div className="mt-1 flex flex-wrap gap-2 text-xs text-brand-500">
-                                      <Badge className="cursor-default bg-brand-100 text-brand-700">
-                                        {topic.sessionsRequired}
-                                      </Badge>
-                                      <Badge className="cursor-default bg-brand-100 text-brand-700">
-                                        {topic.estimatedHours}
-                                      </Badge>
-                                      <span className="rounded-full bg-brand-100 px-3 py-1"># {topic.order}</span>
-                                    </div>
-                                  </div>
-                                  <div className="flex gap-2">
-                                    <Button
-                                      variant="outline"
-                                      size="sm"
-                                      onClick={() => startEditingTopic(topic)}
-                                    >
-                                      {dictionary.topics.editAction}
-                                    </Button>
-                                    <Button
-                                      variant="ghost"
-                                      size="sm"
-                                      onClick={() => handleReorder(course.id, difficulty.id, topic.id, "up")}
-                                    >
-                                      {dictionary.topics.moveUp}
-                                    </Button>
-                                    <Button
-                                      variant="ghost"
-                                      size="sm"
-                                      onClick={() => handleReorder(course.id, difficulty.id, topic.id, "down")}
-                                    >
-                                      {dictionary.topics.moveDown}
-                                    </Button>
-                                  </div>
-                                </div>
-                                {topic.description && !isEditingTopic && (
-                                  <p className="mt-2 text-sm text-brand-600">{topic.description}</p>
-                                )}
-                                {isEditingTopic && topicFormState && (
-                                  <form
-                                    className="mt-4 grid gap-3"
-                                    onSubmit={(event) => {
-                                      event.preventDefault();
-                                      handleUpdateTopic(course.id, topic.id);
-                                    }}
-                                  >
-                                    <div className="grid gap-2">
-                                      <Label>{dictionary.topics.nameLabel}</Label>
-                                      <Input
-                                        value={topicFormState.name}
-                                        onChange={(event) =>
-                                          setTopicEdits((prev) => ({
-                                            ...prev,
-                                            [topic.id]: { ...prev[topic.id], name: event.target.value },
-                                          }))
-                                        }
-                                      />
-                                    </div>
-                                    <div className="grid gap-2">
-                                      <Label>{dictionary.topics.descriptionLabel}</Label>
-                                      <Textarea
-                                        value={topicFormState.description}
-                                        onChange={(event) =>
-                                          setTopicEdits((prev) => ({
-                                            ...prev,
-                                            [topic.id]: { ...prev[topic.id], description: event.target.value },
-                                          }))
-                                        }
-                                      />
-                                    </div>
-                                    <div className="grid gap-2 md:grid-cols-3 md:gap-4">
-                                      <div className="grid gap-2">
-                                        <Label>{dictionary.topics.sessionsLabel}</Label>
-                                        <Input
-                                          type="number"
-                                          min="1"
-                                          value={topicFormState.sessionsRequired}
-                                          onChange={(event) =>
-                                            setTopicEdits((prev) => ({
-                                              ...prev,
-                                              [topic.id]: {
-                                                ...prev[topic.id],
-                                                sessionsRequired: event.target.value,
-                                              },
-                                            }))
-                                          }
-                                        />
-                                      </div>
-                                      <div className="grid gap-2">
-                                        <Label>{dictionary.topics.hoursLabel}</Label>
-                                        <Input
-                                          type="number"
-                                          min="1"
-                                          value={topicFormState.estimatedHours}
-                                          onChange={(event) =>
-                                            setTopicEdits((prev) => ({
-                                              ...prev,
-                                              [topic.id]: {
-                                                ...prev[topic.id],
-                                                estimatedHours: event.target.value,
-                                              },
-                                            }))
-                                          }
-                                        />
-                                      </div>
-                                      <div className="grid gap-2">
-                                        <Label>{dictionary.topics.orderLabel}</Label>
-                                        <Input
-                                          type="number"
-                                          min="1"
-                                          value={topicFormState.order}
-                                          onChange={(event) =>
-                                            setTopicEdits((prev) => ({
-                                              ...prev,
-                                              [topic.id]: {
-                                                ...prev[topic.id],
-                                                order: event.target.value,
-                                              },
-                                            }))
-                                          }
-                                        />
-                                      </div>
-                                    </div>
-                                    <div className="flex gap-2">
-                                      <Button type="submit">{dictionary.topics.submit}</Button>
-                                      <Button
-                                        type="button"
-                                        variant="outline"
-                                        onClick={() => setEditingTopicId(null)}
-                                      >
-                                        {dictionary.topics.cancel}
-                                      </Button>
-                                    </div>
-                                  </form>
-                                )}
-                              </div>
-                            );
-                          })}
-                        </div>
-                      </div>
-                    );
-                  })}
-                </div>
-
-                {activeTopicCourse === course.id && activeTopicDifficulty && (
-                  <div className="rounded-2xl border border-dashed border-brand-200 p-4">
-                    <h4 className="font-semibold text-brand-700">{dictionary.topics.formTitle}</h4>
-                    <form
-                      className="mt-4 grid gap-3"
-                      onSubmit={(event) => {
-                        event.preventDefault();
-                        handleCreateTopic(course.id);
-                      }}
-                    >
+                    <div className="space-y-1">
+                      <p className="font-semibold text-brand-700">
+                        {dictionary.difficulty.labels[difficulty.label] ?? difficulty.label}
+                      </p>
+                      <p className="text-sm text-brand-500">
+                        {formatCurrency(locale, difficulty.pricePerSession)} · {dictionary.table.perSession}
+                      </p>
+                    </div>
+                    <div className="flex flex-col gap-3 md:flex-row md:items-center">
                       <div className="grid gap-2">
-                        <Label>{dictionary.topics.nameLabel}</Label>
+                        <Label className="text-xs text-brand-500">{dictionary.difficulty.priceLabel}</Label>
                         <Input
-                          value={topicForm.name}
-                          onChange={(event) => setTopicForm((prev) => ({ ...prev, name: event.target.value }))}
-                        />
-                      </div>
-                      <div className="grid gap-2">
-                        <Label>{dictionary.topics.descriptionLabel}</Label>
-                        <Textarea
-                          value={topicForm.description}
+                          type="number"
+                          min="0"
+                          value={priceDrafts[difficulty.id] ?? ""}
                           onChange={(event) =>
-                            setTopicForm((prev) => ({ ...prev, description: event.target.value }))
+                            setPriceDrafts((previous) => ({
+                              ...previous,
+                              [difficulty.id]: event.target.value,
+                            }))
                           }
                         />
                       </div>
-                      <div className="grid gap-2 md:grid-cols-3 md:gap-4">
-                        <div className="grid gap-2">
-                          <Label>{dictionary.topics.sessionsLabel}</Label>
-                          <Input
-                            type="number"
-                            min="1"
-                            value={topicForm.sessionsRequired}
-                            onChange={(event) =>
-                              setTopicForm((prev) => ({ ...prev, sessionsRequired: event.target.value }))
-                            }
-                          />
-                        </div>
-                        <div className="grid gap-2">
-                          <Label>{dictionary.topics.hoursLabel}</Label>
-                          <Input
-                            type="number"
-                            min="1"
-                            value={topicForm.estimatedHours}
-                            onChange={(event) =>
-                              setTopicForm((prev) => ({ ...prev, estimatedHours: event.target.value }))
-                            }
-                          />
-                        </div>
-                        <div className="grid gap-2">
-                          <Label>{dictionary.topics.orderLabel}</Label>
-                          <Input
-                            type="number"
-                            min="1"
-                            value={topicForm.order}
-                            onChange={(event) =>
-                              setTopicForm((prev) => ({ ...prev, order: event.target.value }))
-                            }
-                          />
-                        </div>
-                      </div>
                       <div className="flex gap-2">
-                        <Button type="submit">{dictionary.topics.submit}</Button>
                         <Button
                           type="button"
                           variant="outline"
+                          onClick={() => handleUpdateDifficulty(activeCourse.id, difficulty.id)}
+                          disabled={updatingDifficultyId === difficulty.id}
+                        >
+                          {dictionary.updateCourse.saveAction}
+                        </Button>
+                        <Button
+                          type="button"
                           onClick={() => {
-                            setActiveTopicCourse(null);
-                            setActiveTopicDifficulty(null);
-                            setTopicForm(DEFAULT_TOPIC_STATE);
+                            setActiveDifficultyId(difficulty.id);
+                            setView("topics");
                           }}
                         >
-                          {dictionary.topics.cancel}
+                          {dictionary.difficulty.manageTopics}
                         </Button>
                       </div>
-                    </form>
+                    </div>
                   </div>
-                )}
-              </section>
-            </CardContent>
-          </Card>
-        );
-      }),
-    [courses, dictionary, difficultyLabels, editingCourseId, courseEditForm, priceDrafts, topicEdits, activeTopicCourse, activeTopicDifficulty, topicForm, locale],
-  );
-
-  return (
-    <div className="space-y-8">
-      <Card className="border-brand-200 bg-white/90">
-        <CardHeader>
-          <CardTitle>{dictionary.createCourse.title}</CardTitle>
-          <CardDescription>{dictionary.description}</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <form className="grid gap-4 md:grid-cols-2" onSubmit={handleCreateCourse}>
-            <div className="grid gap-2">
-              <Label htmlFor="new-title">{dictionary.createCourse.nameLabel}</Label>
-              <Input
-                id="new-title"
-                value={courseForm.title}
-                onChange={(event) => setCourseForm((prev) => ({ ...prev, title: event.target.value }))}
-              />
+                ))
+              )}
             </div>
-            <div className="grid gap-2">
-              <Label htmlFor="new-category">{dictionary.createCourse.categoryLabel}</Label>
-              <Input
-                id="new-category"
-                value={courseForm.category}
-                onChange={(event) => setCourseForm((prev) => ({ ...prev, category: event.target.value }))}
-              />
-            </div>
-            <div className="grid gap-2 md:col-span-2">
-              <Label htmlFor="new-description">{dictionary.createCourse.descriptionLabel}</Label>
-              <Textarea
-                id="new-description"
-                value={courseForm.description}
-                onChange={(event) => setCourseForm((prev) => ({ ...prev, description: event.target.value }))}
-              />
-            </div>
-            <div className="grid gap-2">
-              <Label>{dictionary.createCourse.typeLabel}</Label>
-              <div className="flex gap-2">
-                {Object.entries(dictionary.createCourse.typeOptions).map(([value, label]) => (
-                  <Button
-                    key={value}
-                    type="button"
-                    variant={courseForm.type === value ? "default" : "outline"}
-                    onClick={() => setCourseForm((prev) => ({ ...prev, type: value as AdminCatalogCourse["type"] }))}
-                  >
-                    {label}
-                  </Button>
-                ))}
+            <div className="space-y-4 rounded-2xl border border-dashed border-brand-200 bg-white/70 p-4">
+              <h3 className="font-semibold text-brand-700">{dictionary.difficulty.addTitle}</h3>
+              <div className="grid gap-3">
+                <div className="grid gap-2">
+                  <Label>{dictionary.difficulty.labelPlaceholder}</Label>
+                  <div className="flex flex-wrap gap-2">
+                    {Object.entries(dictionary.difficulty.labels).map(([value, label]) => (
+                      <Button
+                        key={value}
+                        type="button"
+                        variant={draft.label === value ? "default" : "outline"}
+                        onClick={() =>
+                          setDifficultyDrafts((previous) => ({
+                            ...previous,
+                            [activeCourse.id]: { ...(previous[activeCourse.id] ?? DEFAULT_DIFFICULTY_DRAFT), label: value as DifficultyDraft["label"] },
+                          }))
+                        }
+                      >
+                        {label}
+                      </Button>
+                    ))}
+                  </div>
+                </div>
+                <div className="grid gap-2">
+                  <Label htmlFor="difficultyPrice">{dictionary.difficulty.priceLabel}</Label>
+                  <Input
+                    id="difficultyPrice"
+                    type="number"
+                    min="0"
+                    value={draft.price}
+                    onChange={(event) =>
+                      setDifficultyDrafts((previous) => ({
+                        ...previous,
+                        [activeCourse.id]: { ...(previous[activeCourse.id] ?? DEFAULT_DIFFICULTY_DRAFT), price: event.target.value },
+                      }))
+                    }
+                  />
+                </div>
+                <Button
+                  type="button"
+                  onClick={() => handleCreateDifficulty(activeCourse.id)}
+                  disabled={creatingDifficultyFor === activeCourse.id}
+                >
+                  {dictionary.difficulty.submit}
+                </Button>
               </div>
             </div>
-            <div className="flex items-end justify-end md:col-span-2">
-              <Button type="submit" disabled={isCreatingCourse}>
-                {dictionary.createCourse.submit}
-              </Button>
-            </div>
-          </form>
-        </CardContent>
-      </Card>
+          </div>
+        </div>
+      </section>
+    );
+  };
 
-      <div className="space-y-6">{courseCards}</div>
-    </div>
-  );
+  const renderTopicsView = () => {
+    if (!activeCourse || !activeDifficulty) {
+      return null;
+    }
+    const topicFormState = editingTopicId ? topicEdits[editingTopicId] : undefined;
+
+    return (
+      <section className="space-y-6">
+        <div className="flex flex-wrap gap-3">
+          <Button type="button" variant="outline" onClick={handleBackToDifficulties}>
+            {dictionary.topics.backToDifficulties}
+          </Button>
+        </div>
+
+        <div className="rounded-3xl bg-white/80 p-6 shadow-soft ring-1 ring-brand-100">
+          <div className="space-y-3">
+            <h2 className="font-display text-2xl text-brand-800">{dictionary.topics.title}</h2>
+            <p className="text-sm text-brand-600">
+              {dictionary.difficulty.labels[activeDifficulty.label] ?? activeDifficulty.label} · {formatCurrency(locale, activeDifficulty.pricePerSession)}
+            </p>
+          </div>
+
+          <div className="mt-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <Button type="button" onClick={() => {
+              setIsTopicFormOpen(true);
+              setTopicForm(DEFAULT_TOPIC_STATE);
+            }}>
+              {dictionary.topics.addButton}
+            </Button>
+            <div className="flex items-center gap-2 text-sm text-brand-500">
+              {formatTemplate(dictionary.topics.pageLabel, { current: topicPage, total: totalTopicPages })}
+              <div className="flex gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => setTopicPage((page) => Math.max(1, page - 1))}
+                  disabled={topicPage === 1}
+                >
+                  <span aria-hidden>‹</span>
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => setTopicPage((page) => Math.min(totalTopicPages, page + 1))}
+                  disabled={topicPage === totalTopicPages}
+                >
+                  <span aria-hidden>›</span>
+                </Button>
+              </div>
+            </div>
+          </div>
+
+          {isTopicFormOpen && (
+            <form
+              className="mt-6 space-y-4 rounded-2xl border border-dashed border-brand-200 p-4"
+              onSubmit={(event) => {
+                event.preventDefault();
+                handleCreateTopic(activeCourse.id);
+              }}
+            >
+              <h3 className="font-semibold text-brand-700">{dictionary.topics.formTitle}</h3>
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="grid gap-2 md:col-span-2">
+                  <Label htmlFor="topicName">{dictionary.topics.nameLabel}</Label>
+                  <Input
+                    id="topicName"
+                    value={topicForm.name}
+                    onChange={(event) => setTopicForm((previous) => ({ ...previous, name: event.target.value }))}
+                  />
+                </div>
+                <div className="grid gap-2 md:col-span-2">
+                  <Label htmlFor="topicDescription">{dictionary.topics.descriptionLabel}</Label>
+                  <Textarea
+                    id="topicDescription"
+                    value={topicForm.description}
+                    onChange={(event) => setTopicForm((previous) => ({ ...previous, description: event.target.value }))}
+                  />
+                </div>
+                <div className="grid gap-2">
+                  <Label htmlFor="topicSessions">{dictionary.topics.sessionsLabel}</Label>
+                  <Input
+                    id="topicSessions"
+                    type="number"
+                    min="1"
+                    value={topicForm.sessionsRequired}
+                    onChange={(event) =>
+                      setTopicForm((previous) => ({ ...previous, sessionsRequired: event.target.value }))
+                    }
+                  />
+                </div>
+                <div className="grid gap-2">
+                  <Label htmlFor="topicHours">{dictionary.topics.hoursLabel}</Label>
+                  <Input
+                    id="topicHours"
+                    type="number"
+                    min="1"
+                    value={topicForm.estimatedHours}
+                    onChange={(event) =>
+                      setTopicForm((previous) => ({ ...previous, estimatedHours: event.target.value }))
+                    }
+                  />
+                </div>
+                <div className="grid gap-2">
+                  <Label htmlFor="topicOrder">{dictionary.topics.orderLabel}</Label>
+                  <Input
+                    id="topicOrder"
+                    type="number"
+                    min="1"
+                    value={topicForm.order}
+                    onChange={(event) => setTopicForm((previous) => ({ ...previous, order: event.target.value }))}
+                  />
+                </div>
+              </div>
+              <div className="flex flex-wrap gap-3">
+                <Button type="submit" disabled={isCreatingTopic}>
+                  {dictionary.topics.submit}
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => {
+                    setIsTopicFormOpen(false);
+                    setTopicForm(DEFAULT_TOPIC_STATE);
+                  }}
+                >
+                  {dictionary.topics.cancel}
+                </Button>
+              </div>
+            </form>
+          )}
+
+          <div className="mt-6 space-y-4">
+            {paginatedTopics.length === 0 ? (
+              <p className="text-sm text-brand-500">{dictionary.topics.empty}</p>
+            ) : (
+              paginatedTopics.map((topic) => {
+                const isEditing = editingTopicId === topic.id;
+                const state = isEditing ? topicFormState ?? topicEdits[topic.id] : null;
+                return (
+                  <div key={topic.id} className="space-y-3 rounded-2xl border border-brand-100 bg-white/90 p-4">
+                    <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                      <div>
+                        <p className="font-semibold text-brand-800">{topic.name}</p>
+                        <p className="text-sm text-brand-600">{topic.description}</p>
+                      </div>
+                      <div className="flex flex-wrap gap-2 text-xs text-brand-500">
+                        <span>
+                          {dictionary.topics.sessionsLabel}: {topic.sessionsRequired}
+                        </span>
+                        <span>
+                          {dictionary.topics.hoursLabel}: {topic.estimatedHours}
+                        </span>
+                        <span>
+                          {dictionary.topics.orderLabel}: {topic.order}
+                        </span>
+                      </div>
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        onClick={() => handleReorderTopic(activeCourse.id, topic.id, "up")}
+                        disabled={topic.order === 1}
+                      >
+                        {dictionary.topics.moveUp}
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        onClick={() => handleReorderTopic(activeCourse.id, topic.id, "down")}
+                      >
+                        {dictionary.topics.moveDown}
+                      </Button>
+                      <Button type="button" onClick={() => startEditingTopic(topic.id)}>
+                        {dictionary.topics.editAction}
+                      </Button>
+                    </div>
+                    {isEditing && state && (
+                      <form
+                        className="space-y-3"
+                        onSubmit={(event) => {
+                          event.preventDefault();
+                          handleUpdateTopic(activeCourse.id, topic.id);
+                        }}
+                      >
+                        <div className="grid gap-2 md:grid-cols-2">
+                          <div className="grid gap-2 md:col-span-2">
+                            <Label>{dictionary.topics.nameLabel}</Label>
+                            <Input
+                              value={state.name}
+                              onChange={(event) =>
+                                setTopicEdits((previous) => ({
+                                  ...previous,
+                                  [topic.id]: { ...previous[topic.id], name: event.target.value },
+                                }))
+                              }
+                            />
+                          </div>
+                          <div className="grid gap-2 md:col-span-2">
+                            <Label>{dictionary.topics.descriptionLabel}</Label>
+                            <Textarea
+                              value={state.description}
+                              onChange={(event) =>
+                                setTopicEdits((previous) => ({
+                                  ...previous,
+                                  [topic.id]: { ...previous[topic.id], description: event.target.value },
+                                }))
+                              }
+                            />
+                          </div>
+                          <div className="grid gap-2">
+                            <Label>{dictionary.topics.sessionsLabel}</Label>
+                            <Input
+                              type="number"
+                              min="1"
+                              value={state.sessionsRequired}
+                              onChange={(event) =>
+                                setTopicEdits((previous) => ({
+                                  ...previous,
+                                  [topic.id]: { ...previous[topic.id], sessionsRequired: event.target.value },
+                                }))
+                              }
+                            />
+                          </div>
+                          <div className="grid gap-2">
+                            <Label>{dictionary.topics.hoursLabel}</Label>
+                            <Input
+                              type="number"
+                              min="1"
+                              value={state.estimatedHours}
+                              onChange={(event) =>
+                                setTopicEdits((previous) => ({
+                                  ...previous,
+                                  [topic.id]: { ...previous[topic.id], estimatedHours: event.target.value },
+                                }))
+                              }
+                            />
+                          </div>
+                          <div className="grid gap-2">
+                            <Label>{dictionary.topics.orderLabel}</Label>
+                            <Input
+                              type="number"
+                              min="1"
+                              value={state.order}
+                              onChange={(event) =>
+                                setTopicEdits((previous) => ({
+                                  ...previous,
+                                  [topic.id]: { ...previous[topic.id], order: event.target.value },
+                                }))
+                              }
+                            />
+                          </div>
+                        </div>
+                        <div className="flex flex-wrap gap-3">
+                          <Button type="submit" disabled={updatingTopicId === topic.id}>
+                            {dictionary.topics.submit}
+                          </Button>
+                          <Button type="button" variant="outline" onClick={() => setEditingTopicId(null)}>
+                            {dictionary.topics.cancel}
+                          </Button>
+                        </div>
+                      </form>
+                    )}
+                  </div>
+                );
+              })
+            )}
+          </div>
+        </div>
+      </section>
+    );
+  };
+
+  if (view === "course") {
+    return renderCourseDetail();
+  }
+
+  if (view === "difficulty") {
+    return renderDifficultyView();
+  }
+
+  if (view === "topics") {
+    return renderTopicsView();
+  }
+
+  return renderCourseList();
 }

--- a/i18n/ar.json
+++ b/i18n/ar.json
@@ -249,17 +249,31 @@
     "catalog": {
       "title": "إدارة المحتوى التعليمي",
       "description": "تحكم بالدورات، المستويات، والموضوعات من مكان واحد.",
-      "createCourse": {
-        "title": "إضافة دورة جديدة",
-        "nameLabel": "اسم الدورة",
-        "descriptionLabel": "وصف الدورة",
+      "list": {
+        "searchPlaceholder": "ابحث عن الدورات بالاسم الإنجليزي",
+        "addAction": "إضافة دورة",
+        "emptyTitle": "لا توجد دورات بعد",
+        "emptyDescription": "ابدأ بإضافة دورة جديدة لنشر المسارات التعليمية.",
+        "pageLabel": "الصفحة {{current}} من {{total}}",
+        "viewAction": "عرض التفاصيل"
+      },
+      "forms": {
+        "nameEnLabel": "اسم الدورة (بالإنجليزية)",
+        "nameArLabel": "اسم الدورة (بالعربية)",
+        "descriptionEnLabel": "الوصف (بالإنجليزية)",
+        "descriptionArLabel": "الوصف (بالعربية)",
         "categoryLabel": "التصنيف",
         "typeLabel": "نوع الدورة",
         "typeOptions": {
           "PRIVATE": "خاصة",
           "CLASSROOM": "صفية"
         },
-        "submit": "حفظ الدورة"
+        "submit": "حفظ الدورة",
+        "cancel": "إلغاء"
+      },
+      "createCourse": {
+        "title": "إضافة دورة جديدة",
+        "description": "أدخل التفاصيل باللغتين قبل نشر الدورة."
       },
       "updateCourse": {
         "editAction": "تعديل",
@@ -270,25 +284,49 @@
         "type": "نوع الدورة",
         "category": "التصنيف"
       },
+      "courseDetail": {
+        "backToList": "العودة إلى المحتوى",
+        "overviewTitle": "نظرة عامة على الدورة",
+        "englishHeading": "المحتوى الإنجليزي",
+        "arabicHeading": "المحتوى العربي",
+        "descriptionHeading": "الوصف",
+        "metadataTitle": "معلومات الدورة",
+        "typeLabel": "النوع",
+        "categoryLabel": "التصنيف",
+        "summaryTitle": "ملخص المستويات",
+        "summaryDescription": "راجع الأسعار وعدد الموضوعات لكل مستوى.",
+        "difficultiesCountLabel": "{{count}} مستوى",
+        "topicsCountLabel": "{{count}} موضوع",
+        "manageDifficulties": "إدارة المستويات",
+        "editAction": "تعديل الدورة",
+        "saveAction": "حفظ التغييرات",
+        "cancelAction": "إلغاء"
+      },
       "difficulty": {
         "title": "المستويات",
-        "existingTitle": "المستويات النشطة مع سعر الجلسة.",
+        "description": "أنشئ مستويات خاصة بالدورة وحدّث أسعار الجلسات بالدولار.",
+        "existingTitle": "المستويات الحالية",
         "priceLabel": "سعر الجلسة (دولار)",
         "addTitle": "إضافة مستوى جديد",
         "labelPlaceholder": "اختر المستوى",
         "pricePlaceholder": "مثال: 25",
-        "submit": "إضافة المستوى",
+        "submit": "حفظ المستوى",
         "labels": {
           "BEGINNER": "مبتدئ",
           "INTERMEDIATE": "متوسط",
           "ADVANCED": "متقدم"
-        }
+        },
+        "backToCourse": "العودة إلى الدورة",
+        "manageTopics": "إدارة الموضوعات",
+        "empty": "لم تتم إضافة مستويات بعد.",
+        "pageLabel": "عرض {{from}}-{{to}} من أصل {{total}} مستوى"
       },
       "topics": {
         "title": "الموضوعات",
         "empty": "لم تتم إضافة موضوعات بعد.",
         "addButton": "إضافة موضوع",
         "formTitle": "موضوع جديد",
+        "editTitle": "تعديل الموضوع",
         "nameLabel": "اسم الموضوع",
         "descriptionLabel": "الوصف",
         "sessionsLabel": "عدد الجلسات",
@@ -298,7 +336,9 @@
         "cancel": "إلغاء",
         "editAction": "تعديل",
         "moveUp": "للأعلى",
-        "moveDown": "للأسفل"
+        "moveDown": "للأسفل",
+        "backToDifficulties": "العودة إلى المستويات",
+        "pageLabel": "الصفحة {{current}} من {{total}}"
       },
       "feedback": {
         "courseCreated": "تم إنشاء الدورة",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -262,17 +262,31 @@
     "catalog": {
       "title": "Catalog management",
       "description": "Maintain courses, difficulties, and topics in one workspace.",
-      "createCourse": {
-        "title": "Create a course",
-        "nameLabel": "Course name",
-        "descriptionLabel": "Description",
+      "list": {
+        "searchPlaceholder": "Search courses by English name",
+        "addAction": "Add course",
+        "emptyTitle": "No courses yet",
+        "emptyDescription": "Create your first course to start publishing learning paths.",
+        "pageLabel": "Page {{current}} of {{total}}",
+        "viewAction": "View details"
+      },
+      "forms": {
+        "nameEnLabel": "Course name (English)",
+        "nameArLabel": "Course name (Arabic)",
+        "descriptionEnLabel": "Description (English)",
+        "descriptionArLabel": "Description (Arabic)",
         "categoryLabel": "Category",
         "typeLabel": "Course type",
         "typeOptions": {
           "PRIVATE": "Private",
           "CLASSROOM": "Classroom"
         },
-        "submit": "Save course"
+        "submit": "Save course",
+        "cancel": "Cancel"
+      },
+      "createCourse": {
+        "title": "Create a course",
+        "description": "Add English and Arabic details before publishing the course."
       },
       "updateCourse": {
         "editAction": "Edit",
@@ -283,25 +297,49 @@
         "type": "Course type",
         "category": "Category"
       },
+      "courseDetail": {
+        "backToList": "Back to catalog",
+        "overviewTitle": "Course overview",
+        "englishHeading": "English content",
+        "arabicHeading": "Arabic content",
+        "descriptionHeading": "Description",
+        "metadataTitle": "Course information",
+        "typeLabel": "Type",
+        "categoryLabel": "Category",
+        "summaryTitle": "Difficulty summary",
+        "summaryDescription": "Review pricing and topic counts for each level.",
+        "difficultiesCountLabel": "{{count}} difficulty levels",
+        "topicsCountLabel": "{{count}} topics",
+        "manageDifficulties": "Manage difficulties",
+        "editAction": "Edit course",
+        "saveAction": "Save changes",
+        "cancelAction": "Cancel"
+      },
       "difficulty": {
         "title": "Difficulties",
-        "existingTitle": "Active difficulty levels with session pricing.",
+        "description": "Create levels specific to this course and maintain pricing in USD.",
+        "existingTitle": "Difficulty levels",
         "priceLabel": "Session price (USD)",
         "addTitle": "Add difficulty",
         "labelPlaceholder": "Select level",
         "pricePlaceholder": "e.g. 25",
-        "submit": "Add difficulty",
+        "submit": "Save difficulty",
         "labels": {
           "BEGINNER": "Beginner",
           "INTERMEDIATE": "Intermediate",
           "ADVANCED": "Advanced"
-        }
+        },
+        "backToCourse": "Back to course",
+        "manageTopics": "Manage topics",
+        "empty": "No difficulties have been added yet.",
+        "pageLabel": "Showing {{from}}–{{to}} of {{total}} difficulties"
       },
       "topics": {
         "title": "Topics",
         "empty": "No topics have been added yet.",
         "addButton": "Add topic",
         "formTitle": "New topic",
+        "editTitle": "Edit topic",
         "nameLabel": "Topic name",
         "descriptionLabel": "Description",
         "sessionsLabel": "Sessions",
@@ -311,7 +349,9 @@
         "cancel": "Cancel",
         "editAction": "Edit",
         "moveUp": "Move up",
-        "moveDown": "Move down"
+        "moveDown": "Move down",
+        "backToDifficulties": "Back to difficulties",
+        "pageLabel": "Page {{current}} of {{total}}"
       },
       "feedback": {
         "courseCreated": "Course created",

--- a/lib/types/admin.ts
+++ b/lib/types/admin.ts
@@ -1,9 +1,14 @@
 import type { CourseType, DifficultyLabel } from "@prisma/client";
 
+export type TranslatedField = {
+  en: string;
+  ar: string;
+};
+
 export type AdminCatalogCourse = {
   id: string;
-  title: string;
-  description: string;
+  title: TranslatedField;
+  description: TranslatedField;
   type: CourseType;
   category: string;
   difficulties: {
@@ -25,14 +30,28 @@ export type AdminCatalogCourse = {
 export type AdminCatalogDictionary = {
   title: string;
   description: string;
-  createCourse: {
-    title: string;
-    nameLabel: string;
-    descriptionLabel: string;
+  list: {
+    searchPlaceholder: string;
+    addAction: string;
+    emptyTitle: string;
+    emptyDescription: string;
+    pageLabel: string;
+    viewAction: string;
+  };
+  forms: {
+    nameEnLabel: string;
+    nameArLabel: string;
+    descriptionEnLabel: string;
+    descriptionArLabel: string;
     categoryLabel: string;
     typeLabel: string;
     typeOptions: Record<CourseType, string>;
     submit: string;
+    cancel: string;
+  };
+  createCourse: {
+    title: string;
+    description: string;
   };
   updateCourse: {
     editAction: string;
@@ -43,8 +62,27 @@ export type AdminCatalogDictionary = {
     type: string;
     category: string;
   };
+  courseDetail: {
+    backToList: string;
+    overviewTitle: string;
+    englishHeading: string;
+    arabicHeading: string;
+    descriptionHeading: string;
+    metadataTitle: string;
+    typeLabel: string;
+    categoryLabel: string;
+    summaryTitle: string;
+    summaryDescription: string;
+    difficultiesCountLabel: string;
+    topicsCountLabel: string;
+    manageDifficulties: string;
+    editAction: string;
+    saveAction: string;
+    cancelAction: string;
+  };
   difficulty: {
     title: string;
+    description: string;
     existingTitle: string;
     priceLabel: string;
     addTitle: string;
@@ -52,12 +90,17 @@ export type AdminCatalogDictionary = {
     pricePlaceholder: string;
     submit: string;
     labels: Record<DifficultyLabel, string>;
+    backToCourse: string;
+    manageTopics: string;
+    empty: string;
+    pageLabel: string;
   };
   topics: {
     title: string;
     empty: string;
     addButton: string;
     formTitle: string;
+    editTitle: string;
     nameLabel: string;
     descriptionLabel: string;
     sessionsLabel: string;
@@ -68,6 +111,8 @@ export type AdminCatalogDictionary = {
     editAction: string;
     moveUp: string;
     moveDown: string;
+    backToDifficulties: string;
+    pageLabel: string;
   };
   feedback: {
     courseCreated: string;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -65,8 +65,10 @@ model User {
 
 model Course {
   id            String            @id @default(uuid())
-  title         String            @unique
-  description   String
+  titleEn       String            @unique
+  titleAr       String
+  descriptionEn String
+  descriptionAr String
   type          CourseType
   category      String
   difficulties  CourseDifficulty[]

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -21,23 +21,29 @@ async function main() {
   console.info(`✔️ Admin user ready: ${admin.email}`);
 
   const conversationCourse = await prisma.course.upsert({
-    where: { title: "دورة المحادثة المكثفة" },
+    where: { titleEn: "Intensive Conversation Program" },
     update: {
-      description:
+      titleAr: "دورة المحادثة المكثفة",
+      descriptionEn:
+        "Practical coaching that strengthens speaking fluency through real-life scenarios and guided workshops.",
+      descriptionAr:
         "برنامج عملي يركز على تحسين الطلاقة في التحدث من خلال مواقف حياتية وورش عمل مع المدرب.",
       category: "مهارات المحادثة",
       type: CourseType.PRIVATE,
     },
     create: {
-      title: "دورة المحادثة المكثفة",
-      description:
+      titleEn: "Intensive Conversation Program",
+      titleAr: "دورة المحادثة المكثفة",
+      descriptionEn:
+        "Practical coaching that strengthens speaking fluency through real-life scenarios and guided workshops.",
+      descriptionAr:
         "برنامج عملي يركز على تحسين الطلاقة في التحدث من خلال مواقف حياتية وورش عمل مع المدرب.",
       category: "مهارات المحادثة",
       type: CourseType.PRIVATE,
     },
   });
 
-  console.info(`✔️ Course ready: ${conversationCourse.title}`);
+  console.info(`✔️ Course ready: ${conversationCourse.titleEn} / ${conversationCourse.titleAr}`);
 
   const difficultyData = [
     { label: DifficultyLabel.BEGINNER, pricePerSession: "20.00" },


### PR DESCRIPTION
**Summary**
* Added bilingual course fields and redesigned admin catalog tooling with paginated course, difficulty, and topic management flows, using new dictionary keys and localization helpers. 【F:components/admin/catalog/catalog-manager.tsx†L1-L776】【F:lib/types/admin.ts†L1-L127】【F:i18n/en.json†L262-L355】【F:i18n/ar.json†L249-L340】
* Updated Prisma schema, seed data, and relevant APIs to store and serve English/Arabic course content, and localized public/admin course listings and appointment data. 【F:prisma/schema.prisma†L66-L80】【F:prisma/seed.ts†L23-L47】【F:app/api/admin/courses/route.ts†L1-L103】【F:app/api/courses/route.ts†L1-L23】【F:app/api/appointments/route.ts†L1-L56】
* Adjusted public and admin pages (booking, catalog, calendar, appointments, cash booking) to display localized course titles/descriptions, aligned with the bilingual data model. 【F:app/(public)/courses/page.tsx†L22-L107】【F:app/(public)/booking/page.tsx†L20-L61】【F:app/admin/catalog/page.tsx†L1-L53】【F:app/admin/calendar/page.tsx†L1-L55】【F:app/admin/appointments/page.tsx†L1-L46】【F:app/admin/cash-booking/page.tsx†L1-L43】【F:app/admin/layout.tsx†L1-L51】【F:components/admin/admin-language-initializer.tsx†L1-L40】

**Outstanding TODOs**
* None pending.

**Testing / Warnings**
* ⚠️ `npm run lint` *(not run; dependencies unavailable in current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d79fcdd5008326a2ded53ddffe6de1