### PR TITLE
Update booking and discovery scheduling inputs

### DIFF
--- a/app/(public)/discovery/page.tsx
+++ b/app/(public)/discovery/page.tsx
@@ -51,9 +51,15 @@ export default async function DiscoveryPage() {
                 placeholder={discovery.form.fields.email.placeholder}
               />
             </div>
-            <div className="grid gap-2 text-sm text-brand-600">
-              <Label htmlFor="time">{discovery.form.fields.time.label}</Label>
-              <Input id="time" type="datetime-local" name="time" step={60} />
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="grid gap-2 text-sm text-brand-600">
+                <Label htmlFor="discovery-date">{discovery.form.fields.time.dateLabel}</Label>
+                <Input id="discovery-date" type="date" name="date" />
+              </div>
+              <div className="grid gap-2 text-sm text-brand-600">
+                <Label htmlFor="discovery-time">{discovery.form.fields.time.timeLabel}</Label>
+                <Input id="discovery-time" type="time" name="time" step={3600} />
+              </div>
             </div>
             <Button className="w-full" size="lg">
               {discovery.form.submit}

--- a/i18n/ar.json
+++ b/i18n/ar.json
@@ -114,7 +114,8 @@
           "placeholder": "you@example.com"
         },
         "time": {
-          "label": "الوقت المقترح"
+          "dateLabel": "اليوم المفضل",
+          "timeLabel": "الساعة المفضلة"
         }
       },
       "submit": "حجز الجلسة"
@@ -193,6 +194,13 @@
           "timezone": "الأوقات معروضة حسب توقيت {{timezone}}.",
           "selected": "ستبدأ جلساتك {{count}} في {{date}} الساعة {{time}} وتتكرر أسبوعياً.",
           "sessionsNote": "يتم تثبيت المواعيد الأسبوعية بعد تأكيد الحجز."
+        },
+        "manualAvailability": {
+          "title": "اختر الوقت المناسب لك",
+          "description": "حدد اليوم والساعة الأنسب لاختبار التحديد أو الجلسة التعريفية.",
+          "dateLabel": "اليوم المفضل",
+          "timeLabel": "الساعة المفضلة",
+          "timezone": "الأوقات معروضة حسب توقيت {{timezone}}."
         }
       },
       "summary": {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -114,7 +114,8 @@
           "placeholder": "you@example.com"
         },
         "time": {
-          "label": "Preferred time"
+          "dateLabel": "Preferred day",
+          "timeLabel": "Preferred hour"
         }
       },
       "submit": "Request call"
@@ -193,6 +194,13 @@
           "timezone": "Times shown in {{timezone}}.",
           "selected": "Your {{count}} sessions will start on {{date}} at {{time}} and repeat every week.",
           "sessionsNote": "Weekly sessions are locked once you confirm your booking."
+        },
+        "manualAvailability": {
+          "title": "Pick any convenient time",
+          "description": "Choose the day and hour that work best for your placement or discovery call.",
+          "dateLabel": "Preferred day",
+          "timeLabel": "Preferred hour",
+          "timezone": "Times shown in {{timezone}}."
         }
       },
       "summary": {


### PR DESCRIPTION
## Summary
- split the discovery request form into separate date and hour inputs with hour-only increments
- tailor booking placement options to the learner's level selection and provide a manual scheduling form when the level is unknown
- localize the new scheduling copy in both English and Arabic dictionaries

## Testing
- npm run lint *(fails: next not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d846ba7a4c83268b097e1d853ebfaf